### PR TITLE
enhance project name validation

### DIFF
--- a/openscan_firmware/models/project.py
+++ b/openscan_firmware/models/project.py
@@ -1,12 +1,11 @@
 from datetime import datetime
-import re
+import pathlib
+import unicodedata
 from typing import ClassVar, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
 from openscan_firmware.models.scan import Scan
-
-import pathlib
 
 
 class Project(BaseModel):
@@ -43,8 +42,17 @@ class Project(BaseModel):
 
 
     # Constants for Validation
-    MAX_NAME_LENGTH: ClassVar[int] = 150  # ensures compatability with older Microsoft Windows versions
-    VALID_NAME_PATTERN: ClassVar[re.Pattern] = re.compile(r'^[a-zA-Z0-9_. ][a-zA-Z0-9_\-. ]+[a-zA-Z0-9]$')
+    MAX_NAME_LENGTH: ClassVar[int] = 150  # ensures compatibility with older Microsoft Windows versions
+    FORBIDDEN_CHARACTERS: ClassVar[set[str]] = {"/", "\\", ":", "*", "?", '"', "<", ">", "|"}
+    ALLOWED_PUNCTUATION: ClassVar[set[str]] = {"_", "-", ".", "'"}
+    WINDOWS_RESERVED_NAMES: ClassVar[set[str]] = {
+        "CON",
+        "PRN",
+        "AUX",
+        "NUL",
+        *(f"COM{i}" for i in range(1, 10)),
+        *(f"LPT{i}" for i in range(1, 10)),
+    }
 
     @field_validator('name')
     def validate_name(cls, name: str) -> str:
@@ -59,23 +67,48 @@ class Project(BaseModel):
         Raises:
             ValueError: If name is invalid
         """
-        # check maximum length
-        if len(name) > cls.MAX_NAME_LENGTH:
+        normalized_name = unicodedata.normalize('NFC', name)
+        stripped_name = normalized_name.strip()
+
+        if len(stripped_name) == 0:
+            raise ValueError("The name of the project cannot be empty or whitespace only.")
+
+        # Check maximum length
+        if len(normalized_name) > cls.MAX_NAME_LENGTH:
             raise ValueError(
                 f"The name should not exceed {cls.MAX_NAME_LENGTH} characters."
             )
 
-        if len(name) < 1:
-            raise ValueError("The name of the project cannot be empty.")
+        if normalized_name[0] in {" ", "."} or normalized_name[-1] in {" ", "."}:
+            raise ValueError("The project name must not start or end with a space or period.")
 
-        # Check for invalid characters or patterns
-        if not cls.VALID_NAME_PATTERN.match(name):
+        upper_name = stripped_name.upper()
+        if upper_name in cls.WINDOWS_RESERVED_NAMES:
+            raise ValueError("The project name cannot be one of the reserved Windows names (CON, PRN, AUX, NUL, COM1-9, LPT1-9).")
+
+        for character in normalized_name:
+            category = unicodedata.category(character)
+
+            if character in cls.FORBIDDEN_CHARACTERS:
+                raise ValueError(f"Character '{character}' is not allowed in project names.")
+
+            if category.startswith('C'):
+                raise ValueError("Control characters are not allowed in project names.")
+
+            if category[0] in {"L", "N"}:  # Letters and numbers
+                continue
+
+            if character in cls.ALLOWED_PUNCTUATION:
+                continue
+
+            if category == "Zs":  # space separator
+                continue
+
             raise ValueError(
-                "The project name should only contain characters, numbers, underscores, hyphens and periods. "
-                "It must not start with an hyphen."
+                "The project name contains unsupported characters. Allowed are letters, numbers, spaces, hyphen, underscore, period, and apostrophe."
             )
 
-        return name
+        return normalized_name
 
 
     @field_validator('path')

--- a/openscan_firmware/routers/next/projects.py
+++ b/openscan_firmware/routers/next/projects.py
@@ -103,8 +103,8 @@ async def new_project(project_name: str, project_description: Optional[str] = ""
     try:
         project_manager = get_project_manager()
         return project_manager.add_project(project_name, project_description)
-    except ValueError:
-        raise HTTPException(status_code=400, detail=f"Project {project_name} already exists.")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.post("/{project_name}/scan", response_model=Task)

--- a/openscan_firmware/routers/v0_6/projects.py
+++ b/openscan_firmware/routers/v0_6/projects.py
@@ -78,8 +78,8 @@ async def new_project(project_name: str, project_description: Optional[str] = ""
     try:
         project_manager = get_project_manager()
         return project_manager.add_project(project_name, project_description)
-    except ValueError:
-        raise HTTPException(status_code=400, detail=f"Project {project_name} already exists.")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.post("/{project_name}/scan", response_model=Task)

--- a/openscan_firmware/routers/v0_7/projects.py
+++ b/openscan_firmware/routers/v0_7/projects.py
@@ -103,8 +103,8 @@ async def new_project(project_name: str, project_description: Optional[str] = ""
     try:
         project_manager = get_project_manager()
         return project_manager.add_project(project_name, project_description)
-    except ValueError:
-        raise HTTPException(status_code=400, detail=f"Project {project_name} already exists.")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.post("/{project_name}/scan", response_model=Task)

--- a/tests/controllers/services/test_project_manager.py
+++ b/tests/controllers/services/test_project_manager.py
@@ -79,6 +79,24 @@ async def test_pm_add_project_already_exists(project_manager: ProjectManager):
 
 
 @pytest.mark.asyncio
+async def test_pm_add_project_allows_unicode_characters(project_manager: ProjectManager):
+    """Ensure Unicode letters like umlauts are accepted."""
+    project_name = "Ägäis Projekt 42"
+
+    project = project_manager.add_project(name=project_name)
+
+    assert project.name == "Ägäis Projekt 42"
+    assert project_manager.get_project_by_name(project_name) is project
+
+
+@pytest.mark.asyncio
+async def test_pm_add_project_rejects_forbidden_characters(project_manager: ProjectManager):
+    """Ensure characters invalid on Windows filesystems are rejected."""
+    with pytest.raises(ValueError, match=r"Character ':' is not allowed"):
+        project_manager.add_project(name="Invalid:Project")
+
+
+@pytest.mark.asyncio
 async def test_pm_init_empty_dir(project_manager: ProjectManager):
     """Test ProjectManager initialization with an empty projects directory."""
     # The loading happens in __init__, so we check the result right after (synchronous call).


### PR DESCRIPTION
This PR changes the way project names are validated. Until this change, non-ASCII characters were allowed in a project name. When trying to create such projects with an invalid character, the API would respond with a false error message, saying the project already existed. This is fixed as well.

In addition to now allowing Unicode characters, the validation of project names has been improved to prevent problematic folder names for Windows.