### PR TITLE
Fix/cloud upload tmp space

### DIFF
--- a/openscan_firmware/controllers/services/cloud.py
+++ b/openscan_firmware/controllers/services/cloud.py
@@ -1,11 +1,12 @@
 """Cloud service helpers for OpenScan."""
 
 import asyncio
+import errno
 import io
 import logging
-import math
 import pathlib
 from dataclasses import dataclass
+from shutil import disk_usage
 from tempfile import TemporaryFile
 from typing import Any, BinaryIO, Callable, Iterator, Sequence
 from zipfile import ZIP_DEFLATED, ZipFile
@@ -15,8 +16,9 @@ import requests
 from openscan_firmware.config.cloud import CloudSettings, CloudConfigurationError, get_cloud_settings, mask_secret
 from openscan_firmware.controllers.services.projects import ProjectManager, get_project_manager
 from openscan_firmware.controllers.services.tasks.task_manager import get_task_manager
-from openscan_firmware.models.task import TaskStatus
 from openscan_firmware.models.project import Project
+from openscan_firmware.models.task import TaskStatus
+from openscan_firmware.utils.dir_paths import resolve_runtime_dir
 
 
 logger = logging.getLogger(__name__)
@@ -24,6 +26,7 @@ logger = logging.getLogger(__name__)
 REQUEST_TIMEOUT = 60
 ALLOWED_PHOTO_SUFFIXES = {".jpg", ".jpeg"}
 UNSUPPORTED_PHOTO_SUFFIXES = {".png", ".dng", ".raw", ".cr2", ".cr3", ".crw", ".npy"}
+_CLOUD_TEMP_SUBDIR = "tmp/cloud"
 
 
 class CloudServiceError(RuntimeError):
@@ -50,6 +53,41 @@ class CloudDownloadResult:
     archive_size_bytes: int
     bytes_downloaded: int
     download_info: dict[str, Any]
+
+
+def _get_cloud_temp_dir() -> pathlib.Path:
+    """Resolve and create the temp directory used for large cloud artifacts."""
+
+    temp_dir = resolve_runtime_dir(_CLOUD_TEMP_SUBDIR)
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    return temp_dir
+
+
+def _format_storage_size(size_bytes: int) -> str:
+    """Format byte counts into a compact human-readable string."""
+
+    value = float(size_bytes)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if value < 1024 or unit == "TiB":
+            if unit == "B":
+                return f"{int(value)} {unit}"
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{int(size_bytes)} B"
+
+
+def _temp_storage_error(operation: str, temp_dir: pathlib.Path) -> CloudServiceError:
+    """Build a user-facing error for temporary storage exhaustion."""
+
+    free_space_suffix = ""
+    try:
+        free_space_suffix = f" Free space there: {_format_storage_size(disk_usage(temp_dir).free)}."
+    except OSError:
+        pass
+
+    return CloudServiceError(
+        f"No space left in OpenScan temp storage '{temp_dir}' while {operation}.{free_space_suffix}"
+    )
 
 
 def _require_cloud_settings() -> CloudSettings:
@@ -458,23 +496,33 @@ def _upload_file(
 
 
 def _build_project_archive(project: Project) -> tuple[TemporaryFile, int]:
-    archive = TemporaryFile()
+    temp_dir = _get_cloud_temp_dir()
+    archive = None
     base_path = project.path_obj
 
-    seen_names: set[str] = set()
-    with ZipFile(archive, "w", compression=ZIP_DEFLATED) as zipf:
-        for file_path in _collect_project_photos(project):
-            arcname = file_path.name
-            if arcname in seen_names:
-                arcname = str(file_path.relative_to(base_path)).replace("/", "_")
-            seen_names.add(arcname)
+    try:
+        archive = TemporaryFile(dir=temp_dir)
 
-            zipf.write(file_path, arcname)
+        seen_names: set[str] = set()
+        with ZipFile(archive, "w", compression=ZIP_DEFLATED) as zipf:
+            for file_path in _collect_project_photos(project):
+                arcname = file_path.name
+                if arcname in seen_names:
+                    arcname = str(file_path.relative_to(base_path)).replace("/", "_")
+                seen_names.add(arcname)
 
-    archive.seek(0, io.SEEK_END)
-    size = archive.tell()
-    archive.seek(0)
-    return archive, size
+                zipf.write(file_path, arcname)
+
+        archive.seek(0, io.SEEK_END)
+        size = archive.tell()
+        archive.seek(0)
+        return archive, size
+    except OSError as exc:
+        if archive is not None:
+            archive.close()
+        if exc.errno == errno.ENOSPC:
+            raise _temp_storage_error("creating the cloud upload archive", temp_dir) from exc
+        raise
 
 
 def _count_project_photos(project: Project) -> int:

--- a/openscan_firmware/controllers/services/cloud.py
+++ b/openscan_firmware/controllers/services/cloud.py
@@ -5,9 +5,10 @@ import errno
 import io
 import logging
 import pathlib
+import threading
 from dataclasses import dataclass
 from shutil import disk_usage
-from tempfile import TemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryFile
 from typing import Any, BinaryIO, Callable, Iterator, Sequence
 from zipfile import ZIP_DEFLATED, ZipFile
 
@@ -27,6 +28,12 @@ REQUEST_TIMEOUT = 60
 ALLOWED_PHOTO_SUFFIXES = {".jpg", ".jpeg"}
 UNSUPPORTED_PHOTO_SUFFIXES = {".png", ".dng", ".raw", ".cr2", ".cr3", ".crw", ".npy"}
 _CLOUD_TEMP_SUBDIR = "tmp/cloud"
+_CLOUD_UPLOAD_TEMP_PREFIX = "cloud-upload-"
+_CLOUD_DOWNLOAD_TEMP_PREFIX = "cloud-download-"
+_ZIP_ENTRY_TEMP_OVERHEAD_BYTES = 1024
+_ZIP_FIXED_TEMP_OVERHEAD_BYTES = 64 * 1024
+_ACTIVE_CLOUD_TEMP_PATHS: set[pathlib.Path] = set()
+_CLOUD_TEMP_STATE_LOCK = threading.Lock()
 
 
 class CloudServiceError(RuntimeError):
@@ -88,6 +95,145 @@ def _temp_storage_error(operation: str, temp_dir: pathlib.Path) -> CloudServiceE
     return CloudServiceError(
         f"No space left in OpenScan temp storage '{temp_dir}' while {operation}.{free_space_suffix}"
     )
+
+
+def _insufficient_temp_storage_error(
+    operation: str,
+    temp_dir: pathlib.Path,
+    required_bytes: int,
+    free_bytes: int,
+) -> CloudServiceError:
+    """Build a user-facing error for a failed temp space preflight check."""
+
+    return CloudServiceError(
+        f"Insufficient free space in OpenScan temp storage '{temp_dir}' while {operation}. "
+        f"Required about {_format_storage_size(required_bytes)}, available {_format_storage_size(free_bytes)}."
+    )
+
+
+def _register_active_cloud_temp_path(path: str | pathlib.Path) -> pathlib.Path:
+    """Mark a temp file path as in use by the current process."""
+
+    normalized = pathlib.Path(path)
+    with _CLOUD_TEMP_STATE_LOCK:
+        _ACTIVE_CLOUD_TEMP_PATHS.add(normalized)
+    return normalized
+
+
+def _release_cloud_temp_path(path: str | pathlib.Path | None) -> None:
+    """Remove a temp file path from the active set."""
+
+    if path is None:
+        return
+
+    normalized = pathlib.Path(path)
+    with _CLOUD_TEMP_STATE_LOCK:
+        _ACTIVE_CLOUD_TEMP_PATHS.discard(normalized)
+
+
+def _cleanup_cloud_temp_dir(temp_dir: pathlib.Path) -> tuple[int, int]:
+    """Delete stale files from the dedicated cloud temp directory."""
+
+    removed_count = 0
+    removed_bytes = 0
+
+    try:
+        if not temp_dir.exists():
+            return removed_count, removed_bytes
+    except OSError:
+        return removed_count, removed_bytes
+
+    with _CLOUD_TEMP_STATE_LOCK:
+        active_paths = set(_ACTIVE_CLOUD_TEMP_PATHS)
+        for candidate in sorted(temp_dir.iterdir()):
+            if candidate in active_paths:
+                continue
+
+            try:
+                if not candidate.is_file():
+                    continue
+            except OSError:
+                continue
+
+            try:
+                candidate_size = candidate.stat().st_size
+            except OSError:
+                candidate_size = 0
+
+            try:
+                candidate.unlink()
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                logger.warning("Failed to delete stale cloud temp file %s: %s", candidate, exc)
+                continue
+
+            removed_count += 1
+            removed_bytes += candidate_size
+
+    if removed_count:
+        logger.info(
+            "Removed %s stale cloud temp file(s) from %s, reclaimed %s",
+            removed_count,
+            temp_dir,
+            _format_storage_size(removed_bytes),
+        )
+
+    return removed_count, removed_bytes
+
+
+def _ensure_cloud_temp_space(
+    operation: str,
+    temp_dir: pathlib.Path,
+    required_bytes: int | None = None,
+) -> None:
+    """Run cleanup and fail early when the temp directory lacks free space."""
+
+    _cleanup_cloud_temp_dir(temp_dir)
+    if required_bytes is None or required_bytes <= 0:
+        return
+
+    try:
+        usage = disk_usage(temp_dir)
+    except OSError:
+        return
+
+    if usage.free < required_bytes:
+        raise _insufficient_temp_storage_error(operation, temp_dir, required_bytes, usage.free)
+
+
+def _estimate_upload_temp_space(photo_paths: Sequence[pathlib.Path]) -> int:
+    """Estimate the maximum temp space required for a ZIP archive upload."""
+
+    total_photo_bytes = 0
+    for photo_path in photo_paths:
+        try:
+            total_photo_bytes += photo_path.stat().st_size
+        except OSError as exc:
+            raise CloudServiceError(
+                f"Failed to inspect photo '{photo_path}' before cloud upload."
+            ) from exc
+
+    return (
+        total_photo_bytes
+        + len(photo_paths) * _ZIP_ENTRY_TEMP_OVERHEAD_BYTES
+        + _ZIP_FIXED_TEMP_OVERHEAD_BYTES
+    )
+
+
+def _create_cloud_download_temp_file(temp_dir: pathlib.Path) -> pathlib.Path:
+    """Create and register a named temp file for cloud downloads."""
+
+    with _CLOUD_TEMP_STATE_LOCK:
+        with NamedTemporaryFile(
+            delete=False,
+            suffix=".zip",
+            prefix=_CLOUD_DOWNLOAD_TEMP_PREFIX,
+            dir=temp_dir,
+        ) as temp_file:
+            temp_path = pathlib.Path(temp_file.name)
+            _ACTIVE_CLOUD_TEMP_PATHS.add(temp_path)
+            return temp_path
 
 
 def _require_cloud_settings() -> CloudSettings:
@@ -499,13 +645,16 @@ def _build_project_archive(project: Project) -> tuple[TemporaryFile, int]:
     temp_dir = _get_cloud_temp_dir()
     archive = None
     base_path = project.path_obj
+    photo_paths = _collect_project_photos(project)
+    required_bytes = _estimate_upload_temp_space(photo_paths)
 
     try:
-        archive = TemporaryFile(dir=temp_dir)
+        _ensure_cloud_temp_space("creating the cloud upload archive", temp_dir, required_bytes)
+        archive = TemporaryFile(dir=temp_dir, prefix=_CLOUD_UPLOAD_TEMP_PREFIX)
 
         seen_names: set[str] = set()
         with ZipFile(archive, "w", compression=ZIP_DEFLATED) as zipf:
-            for file_path in _collect_project_photos(project):
+            for file_path in photo_paths:
                 arcname = file_path.name
                 if arcname in seen_names:
                     arcname = str(file_path.relative_to(base_path)).replace("/", "_")

--- a/openscan_firmware/controllers/services/tasks/core/cloud_task.py
+++ b/openscan_firmware/controllers/services/tasks/core/cloud_task.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import errno
 import io
 import logging
 import re
@@ -23,9 +24,11 @@ from openscan_firmware.controllers.services.cloud import (
     _build_project_archive,
     _count_project_photos,
     _create_project,
+    _get_cloud_temp_dir,
     _iter_chunks,
     _require_cloud_settings,
     _start_project,
+    _temp_storage_error,
     get_project_info,
     _upload_file,
 )
@@ -408,9 +411,16 @@ class CloudDownloadTask(BaseTask):
 
         total_bytes = int(response.headers.get("Content-Length", "0") or 0)
         chunk_iter = response.iter_content(chunk_size=_DOWNLOAD_CHUNK_SIZE)
+        temp_dir = await asyncio.to_thread(_get_cloud_temp_dir)
 
-        with NamedTemporaryFile(delete=False, suffix=".zip") as temp_file:
-            temp_path = Path(temp_file.name)
+        try:
+            with NamedTemporaryFile(delete=False, suffix=".zip", dir=temp_dir) as temp_file:
+                temp_path = Path(temp_file.name)
+        except OSError as exc:
+            response.close()
+            if exc.errno == errno.ENOSPC:
+                raise _temp_storage_error("preparing the cloud download archive", temp_dir) from exc
+            raise
 
         downloaded = 0
         try:
@@ -426,7 +436,12 @@ class CloudDownloadTask(BaseTask):
                     if not chunk:
                         continue
 
-                    await asyncio.to_thread(destination.write, chunk)
+                    try:
+                        await asyncio.to_thread(destination.write, chunk)
+                    except OSError as exc:
+                        if exc.errno == errno.ENOSPC:
+                            raise _temp_storage_error("downloading the cloud archive", temp_dir) from exc
+                        raise
                     downloaded += len(chunk)
 
                     total_for_progress = total_bytes or max(downloaded, 1)

--- a/openscan_firmware/controllers/services/tasks/core/cloud_task.py
+++ b/openscan_firmware/controllers/services/tasks/core/cloud_task.py
@@ -10,7 +10,6 @@ import logging
 import re
 import time
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 from typing import Any, AsyncGenerator
 
 import requests
@@ -23,10 +22,13 @@ from openscan_firmware.controllers.services.cloud import (
     REQUEST_TIMEOUT,
     _build_project_archive,
     _count_project_photos,
+    _create_cloud_download_temp_file,
     _create_project,
     _get_cloud_temp_dir,
     _iter_chunks,
+    _ensure_cloud_temp_space,
     _require_cloud_settings,
+    _release_cloud_temp_path,
     _start_project,
     _temp_storage_error,
     get_project_info,
@@ -381,6 +383,7 @@ class CloudDownloadTask(BaseTask):
                         archive_path,
                         exc,
                     )
+            _release_cloud_temp_path(archive_path)
 
     async def _download_archive_stream(
         self,
@@ -411,11 +414,22 @@ class CloudDownloadTask(BaseTask):
 
         total_bytes = int(response.headers.get("Content-Length", "0") or 0)
         chunk_iter = response.iter_content(chunk_size=_DOWNLOAD_CHUNK_SIZE)
+        required_bytes = total_bytes or None
         temp_dir = await asyncio.to_thread(_get_cloud_temp_dir)
-
         try:
-            with NamedTemporaryFile(delete=False, suffix=".zip", dir=temp_dir) as temp_file:
-                temp_path = Path(temp_file.name)
+            await asyncio.to_thread(
+                _ensure_cloud_temp_space,
+                "downloading the cloud archive",
+                temp_dir,
+                required_bytes,
+            )
+        except Exception:
+            response.close()
+            raise
+
+        temp_path: Path | None = None
+        try:
+            temp_path = await asyncio.to_thread(_create_cloud_download_temp_file, temp_dir)
         except OSError as exc:
             response.close()
             if exc.errno == errno.ENOSPC:
@@ -447,7 +461,9 @@ class CloudDownloadTask(BaseTask):
                     total_for_progress = total_bytes or max(downloaded, 1)
                     yield downloaded, total_for_progress
         except Exception:
-            temp_path.unlink(missing_ok=True)
+            if temp_path is not None:
+                temp_path.unlink(missing_ok=True)
+                _release_cloud_temp_path(temp_path)
             response.close()
             raise
         finally:

--- a/openscan_firmware/controllers/services/tasks/task_manager.py
+++ b/openscan_firmware/controllers/services/tasks/task_manager.py
@@ -76,6 +76,9 @@ DEFAULT_AUTODISCOVERY_IGNORE_MODULES = {
 # Configuration for task concurrency
 MAX_CONCURRENT_NON_EXCLUSIVE_TASKS = 3
 TASKS_STORAGE_PATH = pathlib.Path("data/tasks")
+PROGRESS_PERSIST_INTERVAL_SECONDS = 2.0
+PROGRESS_PERSIST_MIN_DELTA_RATIO = 0.05
+PROGRESS_PERSIST_MIN_DELTA_ABSOLUTE = 1.0
 
 
 class TaskManager:
@@ -99,6 +102,8 @@ class TaskManager:
             cls._instance._pending_tasks: asyncio.Queue[tuple[BaseTask, tuple, dict]] = asyncio.Queue()
             cls._instance._active_exclusive_task_id: str | None = None
             cls._instance._queue_processing_lock = asyncio.Lock()
+            cls._instance._last_persisted_progress: dict[str, tuple[float, float, str]] = {}
+            cls._instance._last_persisted_at: dict[str, float] = {}
 
             cls._instance.max_concurrent_non_exclusive_tasks = MAX_CONCURRENT_NON_EXCLUSIVE_TASKS
 
@@ -236,9 +241,49 @@ class TaskManager:
             self._tasks_storage_path.mkdir(parents=True, exist_ok=True)
             with open(file_path, 'w') as f:
                 f.write(json_string)
-            logger.debug(f"Persisted state for task {task_model.id} to {file_path}")
+            self._last_persisted_progress[task_model.id] = (
+                float(task_model.progress.current),
+                float(task_model.progress.total),
+                task_model.progress.message,
+            )
+            self._last_persisted_at[task_model.id] = time.monotonic()
         except IOError as e:
             logger.error(f"Failed to save task state for {task_model.id}: {e}", exc_info=True)
+
+    def _should_persist_progress_state(self, task_model: Task) -> bool:
+        """Persist streaming progress selectively to avoid writing on every micro-update."""
+        last_progress = self._last_persisted_progress.get(task_model.id)
+        last_persisted_at = self._last_persisted_at.get(task_model.id)
+        if last_progress is None or last_persisted_at is None:
+            return True
+
+        now = time.monotonic()
+        if now - last_persisted_at >= PROGRESS_PERSIST_INTERVAL_SECONDS:
+            return True
+
+        current = float(task_model.progress.current)
+        total = float(task_model.progress.total)
+        last_current, last_total, last_message = last_progress
+
+        if current < last_current or total != last_total:
+            return True
+
+        if total <= 0:
+            return current != last_current or task_model.progress.message != last_message
+
+        if current >= total:
+            return True
+
+        min_delta = max(
+            PROGRESS_PERSIST_MIN_DELTA_ABSOLUTE,
+            total * PROGRESS_PERSIST_MIN_DELTA_RATIO,
+        )
+        return (current - last_current) >= min_delta
+
+    def _save_task_progress_state(self, task_model: Task) -> None:
+        """Persist progress updates at a reduced frequency while keeping lifecycle writes immediate."""
+        if self._should_persist_progress_state(task_model):
+            self._save_task_state(task_model)
 
     def _delete_task_state(self, task_id: str):
         """Deletes the JSON file for a given task."""
@@ -247,6 +292,8 @@ class TaskManager:
             if os.path.exists(file_path):
                 os.remove(file_path)
                 logger.debug(f"Deleted persisted state for task {task_id}.")
+            self._last_persisted_progress.pop(task_id, None)
+            self._last_persisted_at.pop(task_id, None)
         except IOError as e:
             logger.error(f"Failed to delete task state for {task_id}: {e}", exc_info=True)
 
@@ -488,7 +535,7 @@ class TaskManager:
 
                         # Update progress. It's now required that tasks yield `TaskProgress` objects.
                         task_model.progress = progress_update
-                        self._save_task_state(task_model)  # Persist progress immediately
+                        self._save_task_progress_state(task_model)
                         await task_event_publisher.publish(task_model, TaskEventType.UPDATE)
 
                     if task_model.status not in [TaskStatus.CANCELLED, TaskStatus.ERROR]:

--- a/tests/controllers/services/tasks/test_cloud_download_task.py
+++ b/tests/controllers/services/tasks/test_cloud_download_task.py
@@ -223,8 +223,8 @@ async def test_cloud_download_task_reports_temp_storage_exhaustion(monkeypatch, 
         assert stream is True
         return FakeResponse()
 
-    def fake_named_temporary_file(*args, **kwargs):
-        raise OSError(errno.ENOSPC, "No space left on device", str(kwargs.get("dir")))
+    def fake_named_temporary_file(temp_dir_arg):
+        raise OSError(errno.ENOSPC, "No space left on device", str(temp_dir_arg))
 
     monkeypatch.setattr(
         "openscan_firmware.controllers.services.tasks.core.cloud_task.get_project_info",
@@ -239,7 +239,7 @@ async def test_cloud_download_task_reports_temp_storage_exhaustion(monkeypatch, 
         lambda: temp_dir,
     )
     monkeypatch.setattr(
-        "openscan_firmware.controllers.services.tasks.core.cloud_task.NamedTemporaryFile",
+        "openscan_firmware.controllers.services.tasks.core.cloud_task._create_cloud_download_temp_file",
         fake_named_temporary_file,
     )
 
@@ -251,6 +251,73 @@ async def test_cloud_download_task_reports_temp_storage_exhaustion(monkeypatch, 
             pass
 
     with pytest.raises(CloudServiceError, match="No space left in OpenScan temp storage") as exc_info:
+        await _consume()
+
+    assert str(temp_dir) in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_cloud_download_task_fails_preflight_when_temp_space_is_insufficient(
+    monkeypatch,
+    project_manager,
+    tmp_path,
+):
+    project = _prepare_environment(monkeypatch, project_manager)
+    temp_dir = tmp_path / "runtime" / "tmp" / "cloud"
+    temp_dir.mkdir(parents=True)
+
+    def fake_get_project_info(name: str, token=None):
+        return {"dlink": "https://download/link", "status": "finished"}
+
+    class FakeResponse:
+        headers = {"Content-Length": "4096"}
+
+        def raise_for_status(self):
+            return None
+
+        def iter_content(self, chunk_size: int):
+            yield b"zip-bytes"
+
+        def close(self):
+            return None
+
+    def fake_requests_get(url: str, stream: bool, timeout: int):
+        assert url == "https://download/link"
+        assert stream is True
+        return FakeResponse()
+
+    def should_not_create_temp_file(_temp_dir):
+        raise AssertionError("Download temp file should not be created when preflight fails")
+
+    monkeypatch.setattr(
+        "openscan_firmware.controllers.services.tasks.core.cloud_task.get_project_info",
+        fake_get_project_info,
+    )
+    monkeypatch.setattr(
+        "openscan_firmware.controllers.services.tasks.core.cloud_task.requests.get",
+        fake_requests_get,
+    )
+    monkeypatch.setattr(
+        "openscan_firmware.controllers.services.tasks.core.cloud_task._get_cloud_temp_dir",
+        lambda: temp_dir,
+    )
+    monkeypatch.setattr(
+        "openscan_firmware.controllers.services.cloud.disk_usage",
+        lambda _path: SimpleNamespace(total=8192, free=512),
+    )
+    monkeypatch.setattr(
+        "openscan_firmware.controllers.services.tasks.core.cloud_task._create_cloud_download_temp_file",
+        should_not_create_temp_file,
+    )
+
+    task_model = Task(name="cloud_download_task", task_type="cloud_download_task")
+    task_instance = CloudDownloadTask(task_model)
+
+    async def _consume():
+        async for _ in task_instance.run(project.name):
+            pass
+
+    with pytest.raises(CloudServiceError, match="Insufficient free space in OpenScan temp storage") as exc_info:
         await _consume()
 
     assert str(temp_dir) in str(exc_info.value)

--- a/tests/controllers/services/tasks/test_cloud_download_task.py
+++ b/tests/controllers/services/tasks/test_cloud_download_task.py
@@ -1,4 +1,5 @@
 import asyncio
+import errno
 from types import SimpleNamespace
 from pathlib import Path
 
@@ -194,3 +195,62 @@ async def test_cloud_download_task_cancel(monkeypatch, project_manager, tmp_path
 
     assert project.downloaded is False
     assert task_instance._task_model.result is None
+
+
+@pytest.mark.asyncio
+async def test_cloud_download_task_reports_temp_storage_exhaustion(monkeypatch, project_manager, tmp_path):
+    project = _prepare_environment(monkeypatch, project_manager)
+    temp_dir = tmp_path / "runtime" / "tmp" / "cloud"
+    temp_dir.mkdir(parents=True)
+
+    def fake_get_project_info(name: str, token=None):
+        return {"dlink": "https://download/link", "status": "finished"}
+
+    class FakeResponse:
+        headers = {"Content-Length": "9"}
+
+        def raise_for_status(self):
+            return None
+
+        def iter_content(self, chunk_size: int):
+            yield b"zip-bytes"
+
+        def close(self):
+            return None
+
+    def fake_requests_get(url: str, stream: bool, timeout: int):
+        assert url == "https://download/link"
+        assert stream is True
+        return FakeResponse()
+
+    def fake_named_temporary_file(*args, **kwargs):
+        raise OSError(errno.ENOSPC, "No space left on device", str(kwargs.get("dir")))
+
+    monkeypatch.setattr(
+        "openscan_firmware.controllers.services.tasks.core.cloud_task.get_project_info",
+        fake_get_project_info,
+    )
+    monkeypatch.setattr(
+        "openscan_firmware.controllers.services.tasks.core.cloud_task.requests.get",
+        fake_requests_get,
+    )
+    monkeypatch.setattr(
+        "openscan_firmware.controllers.services.tasks.core.cloud_task._get_cloud_temp_dir",
+        lambda: temp_dir,
+    )
+    monkeypatch.setattr(
+        "openscan_firmware.controllers.services.tasks.core.cloud_task.NamedTemporaryFile",
+        fake_named_temporary_file,
+    )
+
+    task_model = Task(name="cloud_download_task", task_type="cloud_download_task")
+    task_instance = CloudDownloadTask(task_model)
+
+    async def _consume():
+        async for _ in task_instance.run(project.name):
+            pass
+
+    with pytest.raises(CloudServiceError, match="No space left in OpenScan temp storage") as exc_info:
+        await _consume()
+
+    assert str(temp_dir) in str(exc_info.value)

--- a/tests/controllers/services/tasks/test_cloud_upload_task.py
+++ b/tests/controllers/services/tasks/test_cloud_upload_task.py
@@ -14,7 +14,10 @@ from pytest import MonkeyPatch
 from openscan_firmware.controllers.services.cloud import (
     CloudServiceError,
     _build_project_archive,
+    _cleanup_cloud_temp_dir,
     _count_project_photos,
+    _register_active_cloud_temp_path,
+    _release_cloud_temp_path,
 )
 from openscan_firmware.controllers.services.tasks.core.cloud_task import CloudUploadTask
 from openscan_firmware.models.project import Project
@@ -390,8 +393,9 @@ def test_build_project_archive_uses_cloud_temp_dir(tmp_path, monkeypatch):
     expected_temp_dir = tmp_path / "runtime" / "tmp" / "cloud"
     captured: dict[str, object] = {}
 
-    def fake_temporary_file(*, dir=None):
+    def fake_temporary_file(*, dir=None, prefix=None):
         captured["dir"] = dir
+        captured["prefix"] = prefix
         return io.BytesIO()
 
     monkeypatch.setattr(
@@ -406,6 +410,7 @@ def test_build_project_archive_uses_cloud_temp_dir(tmp_path, monkeypatch):
     archive, size = _build_project_archive(project)
     try:
         assert captured["dir"] == expected_temp_dir
+        assert captured["prefix"] == "cloud-upload-"
         assert size > 0
         with ZipFile(archive, "r") as zipf:
             assert zipf.namelist() == ["img1.jpg"]
@@ -426,7 +431,7 @@ def test_build_project_archive_reports_temp_storage_exhaustion(tmp_path, monkeyp
         scans={},
     )
 
-    def no_space_temp_file(*, dir=None):
+    def no_space_temp_file(*, dir=None, prefix=None):
         raise OSError(errno.ENOSPC, "No space left on device", str(dir))
 
     monkeypatch.setattr(
@@ -439,6 +444,66 @@ def test_build_project_archive_reports_temp_storage_exhaustion(tmp_path, monkeyp
     )
 
     with pytest.raises(CloudServiceError, match="No space left in OpenScan temp storage") as exc_info:
+        _build_project_archive(project)
+
+    assert str(expected_temp_dir) in str(exc_info.value)
+
+
+def test_cleanup_cloud_temp_dir_removes_stale_files_but_keeps_active_files(tmp_path):
+    temp_dir = tmp_path / "runtime" / "tmp" / "cloud"
+    temp_dir.mkdir(parents=True)
+    stale_file = temp_dir / "stale.zip"
+    stale_file.write_bytes(b"old")
+    stale_size = stale_file.stat().st_size
+    active_file = temp_dir / "active.zip"
+    active_file.write_bytes(b"current")
+
+    _register_active_cloud_temp_path(active_file)
+    try:
+        removed_count, removed_bytes = _cleanup_cloud_temp_dir(temp_dir)
+    finally:
+        _release_cloud_temp_path(active_file)
+
+    assert removed_count == 1
+    assert removed_bytes == stale_size
+    assert not stale_file.exists()
+    assert active_file.exists()
+
+
+def test_build_project_archive_fails_preflight_when_temp_space_is_insufficient(tmp_path, monkeypatch):
+    project_path = tmp_path / "project"
+    scan1 = project_path / "scan01"
+    scan1.mkdir(parents=True)
+    (scan1 / "img1.jpg").write_bytes(b"x" * 2048)
+
+    project = Project(
+        name="demo",
+        path=str(project_path),
+        created=datetime.now(),
+        scans={},
+    )
+
+    expected_temp_dir = tmp_path / "runtime" / "tmp" / "cloud"
+    expected_temp_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        "openscan_firmware.controllers.services.cloud._get_cloud_temp_dir",
+        lambda: expected_temp_dir,
+    )
+    monkeypatch.setattr(
+        "openscan_firmware.controllers.services.cloud.disk_usage",
+        lambda _path: SimpleNamespace(total=4096, free=512),
+    )
+
+    def should_not_create_temp_file(**kwargs):
+        raise AssertionError("TemporaryFile should not be created when the preflight check fails")
+
+    monkeypatch.setattr(
+        "openscan_firmware.controllers.services.cloud.TemporaryFile",
+        should_not_create_temp_file,
+    )
+
+    with pytest.raises(CloudServiceError, match="Insufficient free space in OpenScan temp storage") as exc_info:
         _build_project_archive(project)
 
     assert str(expected_temp_dir) in str(exc_info.value)

--- a/tests/controllers/services/tasks/test_cloud_upload_task.py
+++ b/tests/controllers/services/tasks/test_cloud_upload_task.py
@@ -1,4 +1,5 @@
 import asyncio
+import errno
 import io
 import logging
 import time
@@ -371,3 +372,73 @@ def test_build_project_archive_prefers_stacked(tmp_path):
         archive.close()
 
     assert _count_project_photos(project) == 3
+
+
+def test_build_project_archive_uses_cloud_temp_dir(tmp_path, monkeypatch):
+    project_path = tmp_path / "project"
+    scan1 = project_path / "scan01"
+    scan1.mkdir(parents=True)
+    (scan1 / "img1.jpg").write_bytes(b"jpg1")
+
+    project = Project(
+        name="demo",
+        path=str(project_path),
+        created=datetime.now(),
+        scans={},
+    )
+
+    expected_temp_dir = tmp_path / "runtime" / "tmp" / "cloud"
+    captured: dict[str, object] = {}
+
+    def fake_temporary_file(*, dir=None):
+        captured["dir"] = dir
+        return io.BytesIO()
+
+    monkeypatch.setattr(
+        "openscan_firmware.controllers.services.cloud._get_cloud_temp_dir",
+        lambda: expected_temp_dir,
+    )
+    monkeypatch.setattr(
+        "openscan_firmware.controllers.services.cloud.TemporaryFile",
+        fake_temporary_file,
+    )
+
+    archive, size = _build_project_archive(project)
+    try:
+        assert captured["dir"] == expected_temp_dir
+        assert size > 0
+        with ZipFile(archive, "r") as zipf:
+            assert zipf.namelist() == ["img1.jpg"]
+    finally:
+        archive.close()
+
+
+def test_build_project_archive_reports_temp_storage_exhaustion(tmp_path, monkeypatch):
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    expected_temp_dir = tmp_path / "runtime" / "tmp" / "cloud"
+    expected_temp_dir.mkdir(parents=True)
+
+    project = Project(
+        name="demo",
+        path=str(project_path),
+        created=datetime.now(),
+        scans={},
+    )
+
+    def no_space_temp_file(*, dir=None):
+        raise OSError(errno.ENOSPC, "No space left on device", str(dir))
+
+    monkeypatch.setattr(
+        "openscan_firmware.controllers.services.cloud._get_cloud_temp_dir",
+        lambda: expected_temp_dir,
+    )
+    monkeypatch.setattr(
+        "openscan_firmware.controllers.services.cloud.TemporaryFile",
+        no_space_temp_file,
+    )
+
+    with pytest.raises(CloudServiceError, match="No space left in OpenScan temp storage") as exc_info:
+        _build_project_archive(project)
+
+    assert str(expected_temp_dir) in str(exc_info.value)

--- a/tests/controllers/services/test_task_manager.py
+++ b/tests/controllers/services/test_task_manager.py
@@ -467,6 +467,48 @@ async def test_cancel_pending_task(task_manager_fixture: TaskManager):
     await wait_for_task_completion(tm, exclusive_task.id, timeout=4)
 
 
+async def test_streaming_progress_persistence_is_throttled(task_manager_fixture: TaskManager, monkeypatch):
+    """Progress persistence should be reduced for noisy streaming updates."""
+    tm = task_manager_fixture
+    task_model = Task(name="generator_task", task_type="generator_task")
+    persisted_currents = []
+    fake_clock = {"now": 0.0}
+
+    monkeypatch.setattr(task_manager_module, "PROGRESS_PERSIST_INTERVAL_SECONDS", 10.0)
+    monkeypatch.setattr(task_manager_module, "PROGRESS_PERSIST_MIN_DELTA_RATIO", 0.05)
+    monkeypatch.setattr(task_manager_module, "PROGRESS_PERSIST_MIN_DELTA_ABSOLUTE", 1.0)
+    monkeypatch.setattr(task_manager_module.time, "monotonic", lambda: fake_clock["now"])
+
+    original_save = tm._save_task_state
+
+    def recording_save(model: Task):
+        persisted_currents.append(model.progress.current)
+        original_save(model)
+
+    monkeypatch.setattr(tm, "_save_task_state", recording_save)
+
+    task_model.progress = TaskProgress(current=0, total=100, message="starting")
+    tm._save_task_state(task_model)
+
+    fake_clock["now"] = 0.1
+    task_model.progress = TaskProgress(current=1, total=100, message="step 1")
+    tm._save_task_progress_state(task_model)
+
+    fake_clock["now"] = 0.2
+    task_model.progress = TaskProgress(current=5, total=100, message="step 5")
+    tm._save_task_progress_state(task_model)
+
+    fake_clock["now"] = 0.3
+    task_model.progress = TaskProgress(current=6, total=100, message="step 6")
+    tm._save_task_progress_state(task_model)
+
+    fake_clock["now"] = 11.0
+    task_model.progress = TaskProgress(current=7, total=100, message="step 7")
+    tm._save_task_progress_state(task_model)
+
+    assert persisted_currents == [0, 5, 7]
+
+
 # --- Tests for Persistence ---
 
 async def test_task_state_is_persisted_across_lifecycle(task_manager_fixture: TaskManager):


### PR DESCRIPTION
This PR fixes #104 by
- creating the to-be-uploaded zip archive of a project outside the temp partition.
-  ensuring proper cleanup of zip archives

This PR also improves performance by lowering the frequency of persisting task progress writes to disk.