### PR TITLE
Allow equal phi and theta angles in constrained paths

### DIFF
--- a/openscan_firmware/config/scan.py
+++ b/openscan_firmware/config/scan.py
@@ -22,13 +22,13 @@ class ScanSetting(BaseModel):
     max_theta: float = Field(125.0, ge=0.0, le=180.0,
                              description="Maximum theta angle in degrees for constrained paths.")
     min_phi: float | None = Field(
-        default=None,
+        default=0,
         ge=0.0,
         le=360.0,
         description="Optional minimum phi angle in degrees for constrained paths.",
     )
     max_phi: float | None = Field(
-        default=None,
+        default=360.0,
         ge=0.0,
         le=360.0,
         description="Optional maximum phi angle in degrees for constrained paths.",

--- a/openscan_firmware/utils/paths/paths.py
+++ b/openscan_firmware/utils/paths/paths.py
@@ -116,15 +116,12 @@ def get_constrained_path(
     if min_theta < 0 or max_theta > 180:
         logger.error("Theta angle must be between 0° and 180°")
         raise ValueError("Theta angle must be between 0° and 180°")
-    if min_theta >= max_theta:
-        logger.error("Minimum theta angle must be less than maximum theta angle")
-        raise ValueError("Minimum theta angle must be less than maximum theta angle")
+    if min_theta > max_theta:
+        logger.error("Minimum theta angle must be less than or equal to maximum theta angle")
+        raise ValueError("Minimum theta angle must be less than or equal to maximum theta angle")
     if min_phi < 0 or min_phi > 360 or max_phi < 0 or max_phi > 360:
         logger.error("Phi angle must be between 0° and 360°")
         raise ValueError("Phi angle must be between 0° and 360°")
-    if min_phi == max_phi:
-        logger.error("Minimum phi angle must not be equal to maximum phi angle")
-        raise ValueError("Minimum phi angle must not be equal to maximum phi angle")
 
     if method == PathMethod.FIBONACCI:
         return _generate_constrained_fibonacci(
@@ -141,6 +138,9 @@ def get_constrained_path(
 
 def _phi_span(min_phi: float, max_phi: float) -> float:
     """Return the positive span of a phi interval, supporting wrap-around at 360°."""
+    if min_phi == max_phi:
+        return 0.0
+
     span = (max_phi - min_phi) % 360
     return 360 if span == 0 else span
 
@@ -171,6 +171,9 @@ def _generate_constrained_fibonacci(
         min_phi,
         max_phi,
     )
+    if min_theta == max_theta and min_phi == max_phi:
+        return [PolarPoint3D(theta=min_theta, fi=min_phi % 360, r=1.0)]
+
     # Convert theta constraints to Z constraints
     # theta = arccos(z), so z = cos(theta)
     # Note: theta increases as z decreases

--- a/tests/config/test_scan_config.py
+++ b/tests/config/test_scan_config.py
@@ -2,13 +2,13 @@ from openscan_firmware.config.external_trigger_run import ExternalTriggerRunSett
 from openscan_firmware.config.scan import ScanSetting
 
 
-def test_scan_settings_omit_unset_phi_fields_from_json_dump() -> None:
+def test_scan_settings_include_default_phi_fields_in_json_dump() -> None:
     settings = ScanSetting()
 
     payload = settings.model_dump(mode="json")
 
-    assert "min_phi" not in payload
-    assert "max_phi" not in payload
+    assert payload["min_phi"] == 0
+    assert payload["max_phi"] == 360.0
 
 
 def test_external_trigger_run_settings_omit_unset_phi_fields_from_json_dump() -> None:

--- a/tests/controllers/hardware/picamera2/test_picamera2_focus_unit.py
+++ b/tests/controllers/hardware/picamera2/test_picamera2_focus_unit.py
@@ -28,9 +28,11 @@ def _import_picamera2_module(monkeypatch):
 
     picamera2 = types.ModuleType("picamera2")
     picamera2.Picamera2 = type("Picamera2", (), {})
+    cv2 = types.ModuleType("cv2")
 
     monkeypatch.setitem(sys.modules, "libcamera", libcamera)
     monkeypatch.setitem(sys.modules, "picamera2", picamera2)
+    monkeypatch.setitem(sys.modules, "cv2", cv2)
     sys.modules.pop("openscan_firmware.controllers.hardware.cameras.picamera2", None)
 
     return importlib.import_module("openscan_firmware.controllers.hardware.cameras.picamera2")

--- a/tests/controllers/hardware/test_gpio.py
+++ b/tests/controllers/hardware/test_gpio.py
@@ -1,0 +1,52 @@
+import pytest
+
+from openscan_firmware.controllers.hardware import gpio as gpio_module
+
+
+class _FakeDigitalOutputDevice:
+    def __init__(self, pin: int, initial_value: bool = False):
+        self.pin = pin
+        self.value = bool(initial_value)
+
+    def toggle(self):
+        self.value = not self.value
+
+    def close(self):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def reset_gpio_state(monkeypatch):
+    original_outputs = gpio_module._output_pins.copy()
+    original_buttons = gpio_module._buttons.copy()
+
+    gpio_module._output_pins.clear()
+    gpio_module._buttons.clear()
+    monkeypatch.setattr(gpio_module, "DigitalOutputDevice", _FakeDigitalOutputDevice)
+
+    yield
+
+    gpio_module._output_pins.clear()
+    gpio_module._buttons.clear()
+    gpio_module._output_pins.update(original_outputs)
+    gpio_module._buttons.update(original_buttons)
+
+
+def test_set_output_pin_auto_initializes_when_pin_is_free():
+    result = gpio_module.set_output_pin(10, True, auto_initialize=True)
+
+    assert result is True
+    assert 10 in gpio_module._output_pins
+    assert gpio_module.get_output_pin(10) is True
+
+
+def test_set_output_pin_rejects_pin_initialized_as_button():
+    gpio_module._buttons[10] = object()
+
+    with pytest.raises(ValueError, match="initialized as button input"):
+        gpio_module.set_output_pin(10, True, auto_initialize=True)
+
+
+def test_set_output_pin_requires_initialized_output_without_auto_init():
+    with pytest.raises(ValueError, match="not initialized as output"):
+        gpio_module.set_output_pin(11, True)

--- a/tests/controllers/hardware/test_motor.py
+++ b/tests/controllers/hardware/test_motor.py
@@ -1,5 +1,6 @@
 import pytest
 import asyncio  # Still needed for async functions
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock  # Keep for specific mock types
 
 # Adjust paths if necessary for your project structure
@@ -55,7 +56,7 @@ def motor_event_loop():
 
 @pytest.fixture
 def mocked_dependencies(monkeypatch, motor_event_loop):
-    """Mocks GPIO, time.sleep, math.cos, and event_loop.run_in_executor."""
+    """Mocks GPIO, time.sleep, math.cos, and the low-level movement executor."""
 
     import openscan_firmware.controllers.hardware.motors as motors_module
 
@@ -67,12 +68,12 @@ def mocked_dependencies(monkeypatch, motor_event_loop):
 
     mock_math_cos = MagicMock(return_value=0.0)
     monkeypatch.setattr(motors_module.math, 'cos', mock_math_cos)
+    async def fake_execute_movement(self, step_count: int, requested_degrees: float) -> int:
+        self.model.angle = requested_degrees % 360
+        return abs(step_count)
 
-    def sync_run_in_executor_side_effect(executor, callback, *args):
-        return callback(*args)
-
-    mock_run_in_executor = AsyncMock(side_effect=sync_run_in_executor_side_effect)
-    monkeypatch.setattr(motor_event_loop, 'run_in_executor', mock_run_in_executor, raising=True)
+    monkeypatch.setattr(MotorController, '_execute_movement', fake_execute_movement)
+    mock_run_in_executor = AsyncMock()
 
     return {
         "gpio": mock_gpio,
@@ -80,6 +81,40 @@ def mocked_dependencies(monkeypatch, motor_event_loop):
         "math_cos": mock_math_cos,
         "run_in_executor": mock_run_in_executor,
         "event_loop": motor_event_loop,
+    }
+
+
+@pytest.fixture
+def movement_dependencies(monkeypatch):
+    """Mocks hardware and executor boundaries while keeping _execute_movement real."""
+    import openscan_firmware.controllers.hardware.motors as motors_module
+
+    mock_gpio = MagicMock()
+    monkeypatch.setattr(motors_module, 'gpio', mock_gpio)
+    monkeypatch.setattr(motors_module.time, 'sleep', MagicMock())
+    monkeypatch.setattr(motors_module, 'notify_busy_change', MagicMock())
+
+    class ImmediateExecutorLoop:
+        def run_in_executor(self, executor, callback, *args):
+            future = asyncio.Future()
+            try:
+                future.set_result(callback(*args))
+            except Exception as exc:
+                future.set_exception(exc)
+            return future
+
+    monkeypatch.setattr(
+        motors_module,
+        'asyncio',
+        SimpleNamespace(
+            CancelledError=asyncio.CancelledError,
+            get_event_loop=MagicMock(return_value=ImmediateExecutorLoop()),
+        ),
+    )
+
+    return {
+        "gpio": mock_gpio,
+        "notify_busy_change": motors_module.notify_busy_change,
     }
 
 
@@ -245,3 +280,77 @@ async def test_move_to_with_clamping(motor_controller_clamping_instance, motor_m
         assert motor_model.angle == pytest.approx(expected_angle, abs=1), \
             f"Angle mismatch for move_to({target_val}) from {initial_angle}"
 
+
+@pytest.fixture
+def movement_motor_controller(movement_dependencies):
+    settings = MotorConfig(
+        direction_pin=1,
+        enable_pin=2,
+        step_pin=3,
+        acceleration=20000,
+        max_speed=7500,
+        min_angle=0,
+        max_angle=360,
+        direction=1,
+        steps_per_rotation=3200,
+    )
+    controller = MotorController(Motor(name="test_motor", settings=settings, angle=0.0))
+    controller.set_idle_callbacks(lambda: False, AsyncMock())
+    controller._pre_calculate_step_times = MagicMock(return_value=[0.0, 0.0, 0.0])
+    return controller
+
+
+@pytest.mark.asyncio
+async def test_execute_movement_sets_direction_and_steps_forward(movement_motor_controller, movement_dependencies):
+    controller = movement_motor_controller
+
+    await controller._execute_movement(3, 0.0)
+
+    assert controller.model.angle == pytest.approx(3 / 3200 * 360)
+    movement_dependencies["gpio"].set_output_pin.assert_any_call(controller.settings.direction_pin, True)
+    assert movement_dependencies["gpio"].set_output_pin.call_args_list.count(
+        ((controller.settings.step_pin, True),)
+    ) == 3
+    assert movement_dependencies["gpio"].set_output_pin.call_args_list.count(
+        ((controller.settings.step_pin, False),)
+    ) == 3
+    assert controller._current_steps == 0
+
+
+@pytest.mark.asyncio
+async def test_execute_movement_sets_direction_and_updates_angle_backward(
+    movement_motor_controller,
+    movement_dependencies,
+):
+    controller = movement_motor_controller
+    controller.model.angle = 10.0
+
+    await controller._execute_movement(-3, 0.0)
+
+    assert controller.model.angle == pytest.approx((10.0 - (3 / 3200 * 360)) % 360)
+    movement_dependencies["gpio"].set_output_pin.assert_any_call(controller.settings.direction_pin, False)
+
+
+@pytest.mark.asyncio
+async def test_execute_movement_stops_when_stop_requested(
+    movement_motor_controller,
+    movement_dependencies,
+):
+    controller = movement_motor_controller
+    controller._pre_calculate_step_times = MagicMock(return_value=[0.0, 1.0, 2.0, 3.0])
+
+    step_high_calls = 0
+
+    def set_output_pin(pin, value):
+        nonlocal step_high_calls
+        if pin == controller.settings.step_pin and value is True:
+            step_high_calls += 1
+            controller._stop_requested = True
+
+    movement_dependencies["gpio"].set_output_pin.side_effect = set_output_pin
+
+    await controller._execute_movement(4, 0.0)
+
+    assert step_high_calls == 1
+    assert controller.model.angle == pytest.approx(1 / 3200 * 360)
+    assert controller._current_steps == 0

--- a/tests/controllers/services/test_scan_task.py
+++ b/tests/controllers/services/test_scan_task.py
@@ -196,7 +196,7 @@ class TestScanTask:
         )
 
 
-def test_generate_scan_path_omits_optional_phi_constraints_when_unset() -> None:
+def test_generate_scan_path_passes_default_phi_constraints() -> None:
     scan_settings = ScanSetting(
         path_method=PathMethod.FIBONACCI,
         points=10,
@@ -222,6 +222,8 @@ def test_generate_scan_path_omits_optional_phi_constraints_when_unset() -> None:
         "num_points": 10,
         "min_theta": 10.0,
         "max_theta": 120.0,
+        "min_phi": 0,
+        "max_phi": 360.0,
     }
     assert list(path_dict.keys()) == [PolarPoint3D(theta=10.0, fi=20.0, r=250.0)]
 
@@ -707,6 +709,29 @@ def test_generate_scan_path_passes_optional_phi_constraints_when_set() -> None:
         assert camera_controller.photo_async.await_count == len(focus_positions)
         for awaited_call in camera_controller.photo_async.await_args_list:
             assert awaited_call.args == ("rgb_array",)
+
+
+def test_generate_scan_path_fully_fixed_position_has_single_zero_index_step() -> None:
+    scan_settings = ScanSetting(
+        path_method=PathMethod.FIBONACCI,
+        points=130,
+        min_theta=45.0,
+        max_theta=45.0,
+        min_phi=90.0,
+        max_phi=90.0,
+        optimize_path=False,
+        focus_stacks=1,
+        focus_range=(10.0, 15.0),
+        image_format="jpeg",
+    )
+
+    with patch(
+        "openscan_firmware.controllers.services.tasks.core.scan_task._get_scan_radius_mm",
+        return_value=250.0,
+    ):
+        path_dict = generate_scan_path(scan_settings)
+
+    assert path_dict == {PolarPoint3D(theta=45.0, fi=90.0, r=250.0): 0}
 
 
 class TestScanTaskIntegration:

--- a/tests/controllers/services/test_scan_task.py
+++ b/tests/controllers/services/test_scan_task.py
@@ -196,71 +196,6 @@ class TestScanTask:
         )
 
 
-def test_generate_scan_path_passes_default_phi_constraints() -> None:
-    scan_settings = ScanSetting(
-        path_method=PathMethod.FIBONACCI,
-        points=10,
-        min_theta=10.0,
-        max_theta=120.0,
-        optimize_path=False,
-        focus_stacks=1,
-        focus_range=(10.0, 15.0),
-        image_format="jpeg",
-    )
-
-    with patch(
-        "openscan_firmware.controllers.services.tasks.core.scan_task._get_scan_radius_mm",
-        return_value=250.0,
-    ), patch(
-        "openscan_firmware.controllers.services.tasks.core.scan_task.paths.get_constrained_path",
-        return_value=[PolarPoint3D(theta=10.0, fi=20.0)],
-    ) as get_constrained_path:
-        path_dict = generate_scan_path(scan_settings)
-
-    assert get_constrained_path.call_args.kwargs == {
-        "method": PathMethod.FIBONACCI,
-        "num_points": 10,
-        "min_theta": 10.0,
-        "max_theta": 120.0,
-        "min_phi": 0,
-        "max_phi": 360.0,
-    }
-    assert list(path_dict.keys()) == [PolarPoint3D(theta=10.0, fi=20.0, r=250.0)]
-
-
-def test_generate_scan_path_passes_optional_phi_constraints_when_set() -> None:
-    scan_settings = ScanSetting(
-        path_method=PathMethod.FIBONACCI,
-        points=10,
-        min_theta=10.0,
-        max_theta=120.0,
-        min_phi=45.0,
-        max_phi=180.0,
-        optimize_path=False,
-        focus_stacks=1,
-        focus_range=(10.0, 15.0),
-        image_format="jpeg",
-    )
-
-    with patch(
-        "openscan_firmware.controllers.services.tasks.core.scan_task._get_scan_radius_mm",
-        return_value=250.0,
-    ), patch(
-        "openscan_firmware.controllers.services.tasks.core.scan_task.paths.get_constrained_path",
-        return_value=[PolarPoint3D(theta=10.0, fi=20.0)],
-    ) as get_constrained_path:
-        path_dict = generate_scan_path(scan_settings)
-
-    assert get_constrained_path.call_args.kwargs == {
-        "method": PathMethod.FIBONACCI,
-        "num_points": 10,
-        "min_theta": 10.0,
-        "max_theta": 120.0,
-        "min_phi": 45.0,
-        "max_phi": 180.0,
-    }
-    assert list(path_dict.keys()) == [PolarPoint3D(theta=10.0, fi=20.0, r=250.0)]
-
     @pytest.mark.asyncio
     @patch('openscan_firmware.controllers.hardware.cameras.camera.get_camera_controller')
     @patch('openscan_firmware.controllers.services.tasks.core.scan_task.get_project_manager')
@@ -427,27 +362,13 @@ def test_generate_scan_path_passes_optional_phi_constraints_when_set() -> None:
         assert final_task_model.status == TaskStatus.COMPLETED
 
     @pytest.mark.asyncio
-    @patch('openscan_firmware.controllers.hardware.cameras.camera.get_camera_controller')
-    @patch('openscan_firmware.controllers.services.tasks.core.scan_task.get_project_manager')
-    @patch('openscan_firmware.controllers.services.tasks.core.scan_task.generate_scan_path')
-    @patch('openscan_firmware.controllers.hardware.motors', create=True)
     async def test_focus_stacking_pause_and_resume_mid_capture(
         self,
-        mock_motors: MagicMock,
-        mock_generate_scan_path: MagicMock,
-        mock_get_project_manager: MagicMock,
-        mock_get_camera_controller: MagicMock,
-        task_manager_fixture: TaskManager,
         mock_camera_controller: MagicMock,
         sample_scan_model: Scan,
-        mock_project_manager: MagicMock,
         fake_photo_data: PhotoData,
     ):
         """Ensure pausing during focus stacking resumes cleanly mid-stack."""
-
-        mock_get_camera_controller.return_value = mock_camera_controller
-        mock_get_project_manager.return_value = mock_project_manager
-
         scan = sample_scan_model.model_copy(deep=True)
         scan.settings.focus_stacks = 12
         scan.settings.focus_range = (0.1, 0.4)
@@ -456,52 +377,58 @@ def test_generate_scan_path_passes_optional_phi_constraints_when_set() -> None:
         focus_settings = FocusTrackingSettings(AF=True, manual_focus=0.05)
         mock_camera_controller.settings = focus_settings
 
-        path_points = {
-            PolarPoint3D(theta=0, fi=0): 0,
-            PolarPoint3D(theta=15, fi=15): 1,
-        }
-        mock_generate_scan_path.return_value = path_points
-        mock_motors.move_to_point = AsyncMock(return_value=None)
-
         capture_event = asyncio.Event()
         photo_counter = {"count": 0}
         pause_trigger_index = 2
 
-        def slow_focus_photo(*args, **kwargs):
+        async def slow_focus_photo(*args, **kwargs):
             photo_counter["count"] += 1
             if photo_counter["count"] == pause_trigger_index:
                 capture_event.set()
-            time.sleep(0.05)
+            await asyncio.sleep(0.05)
             return fake_photo_data
 
         async def slow_add_photo(*args, **kwargs):
             await asyncio.sleep(0.01)
 
-        mock_camera_controller.photo.side_effect = slow_focus_photo
-        mock_project_manager.add_photo_async.side_effect = slow_add_photo
+        mock_camera_controller.photo_async = AsyncMock(side_effect=slow_focus_photo)
+        project_manager = MagicMock()
+        project_manager.add_photo_async = AsyncMock(side_effect=slow_add_photo)
 
-        tm = task_manager_fixture
-        task_model = await tm.create_and_run_task("scan_task", scan, 0)
+        task_model = Task(name="scan_task", task_type="core")
+        scan_task = ScanTask(task_model)
+        scan_task._ctx = ScanRuntime(
+            scan=scan,
+            camera_controller=mock_camera_controller,
+            project_manager=project_manager,
+            path_dict={PolarPoint3D(theta=0, fi=0): 0},
+            focus_context={
+                "enabled": True,
+                "positions": focus_positions,
+                "previous_settings": (focus_settings.AF, focus_settings.manual_focus),
+            },
+        )
+
+        capture_task = asyncio.create_task(
+            scan_task._capture_photos_at_position(PolarPoint3D(theta=0, fi=0), 0)
+        )
 
         await asyncio.wait_for(capture_event.wait(), timeout=2.0)
-        paused_task = await tm.pause_task(task_model.id)
-        assert paused_task.status == TaskStatus.PAUSED
-        assert mock_camera_controller.photo.call_count < scan.settings.focus_stacks
+        scan_task.pause()
+        assert mock_camera_controller.photo_async.await_count < scan.settings.focus_stacks
 
         await asyncio.sleep(0.05)
+        assert scan_task.is_paused()
 
-        resumed_task = await tm.resume_task(task_model.id)
-        assert resumed_task.status == TaskStatus.RUNNING
+        scan_task.resume()
+        await capture_task
+        await asyncio.sleep(0)
 
-        final_task_model = await tm.wait_for_task(task_model.id)
-        assert final_task_model.status == TaskStatus.COMPLETED
+        expected_photos = scan.settings.focus_stacks
+        assert mock_camera_controller.photo_async.await_count == expected_photos
+        assert project_manager.add_photo_async.await_count == expected_photos
 
-        expected_photos = scan.settings.focus_stacks * len(path_points)
-        assert mock_camera_controller.photo.call_count == expected_photos
-        assert mock_project_manager.add_photo_async.await_count == expected_photos
-
-        expected_history = focus_positions * len(path_points) + [0.05]
-        assert focus_settings.history == expected_history
+        assert focus_settings.history == focus_positions
 
     @pytest.mark.asyncio
     @patch('openscan_firmware.controllers.hardware.cameras.camera.get_camera_controller')
@@ -709,6 +636,72 @@ def test_generate_scan_path_passes_optional_phi_constraints_when_set() -> None:
         assert camera_controller.photo_async.await_count == len(focus_positions)
         for awaited_call in camera_controller.photo_async.await_args_list:
             assert awaited_call.args == ("rgb_array",)
+
+
+def test_generate_scan_path_passes_default_phi_constraints() -> None:
+    scan_settings = ScanSetting(
+        path_method=PathMethod.FIBONACCI,
+        points=10,
+        min_theta=10.0,
+        max_theta=120.0,
+        optimize_path=False,
+        focus_stacks=1,
+        focus_range=(10.0, 15.0),
+        image_format="jpeg",
+    )
+
+    with patch(
+        "openscan_firmware.controllers.services.tasks.core.scan_task._get_scan_radius_mm",
+        return_value=250.0,
+    ), patch(
+        "openscan_firmware.controllers.services.tasks.core.scan_task.paths.get_constrained_path",
+        return_value=[PolarPoint3D(theta=10.0, fi=20.0)],
+    ) as get_constrained_path:
+        path_dict = generate_scan_path(scan_settings)
+
+    assert get_constrained_path.call_args.kwargs == {
+        "method": PathMethod.FIBONACCI,
+        "num_points": 10,
+        "min_theta": 10.0,
+        "max_theta": 120.0,
+        "min_phi": 0,
+        "max_phi": 360.0,
+    }
+    assert list(path_dict.keys()) == [PolarPoint3D(theta=10.0, fi=20.0, r=250.0)]
+
+
+def test_generate_scan_path_passes_optional_phi_constraints_when_set() -> None:
+    scan_settings = ScanSetting(
+        path_method=PathMethod.FIBONACCI,
+        points=10,
+        min_theta=10.0,
+        max_theta=120.0,
+        min_phi=45.0,
+        max_phi=180.0,
+        optimize_path=False,
+        focus_stacks=1,
+        focus_range=(10.0, 15.0),
+        image_format="jpeg",
+    )
+
+    with patch(
+        "openscan_firmware.controllers.services.tasks.core.scan_task._get_scan_radius_mm",
+        return_value=250.0,
+    ), patch(
+        "openscan_firmware.controllers.services.tasks.core.scan_task.paths.get_constrained_path",
+        return_value=[PolarPoint3D(theta=10.0, fi=20.0)],
+    ) as get_constrained_path:
+        path_dict = generate_scan_path(scan_settings)
+
+    assert get_constrained_path.call_args.kwargs == {
+        "method": PathMethod.FIBONACCI,
+        "num_points": 10,
+        "min_theta": 10.0,
+        "max_theta": 120.0,
+        "min_phi": 45.0,
+        "max_phi": 180.0,
+    }
+    assert list(path_dict.keys()) == [PolarPoint3D(theta=10.0, fi=20.0, r=250.0)]
 
 
 def test_generate_scan_path_fully_fixed_position_has_single_zero_index_step() -> None:

--- a/tests/routers/test_next_gpio_router.py
+++ b/tests/routers/test_next_gpio_router.py
@@ -1,0 +1,46 @@
+from importlib import import_module
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def gpio_client_next() -> TestClient:
+    app = FastAPI()
+    gpio_router = import_module("openscan_firmware.routers.next.gpio")
+    app.include_router(gpio_router.router, prefix="/next")
+    with TestClient(app) as client:
+        yield client
+
+
+def test_next_gpio_patch_sets_pin_with_auto_init(monkeypatch, gpio_client_next):
+    module_path = "openscan_firmware.routers.next.gpio"
+    captured: dict[str, tuple[int, bool, bool]] = {}
+
+    def fake_set_output_pin(pin: int, status: bool, auto_initialize: bool = False):
+        captured["args"] = (pin, status, auto_initialize)
+        return status
+
+    monkeypatch.setattr(f"{module_path}.gpio.set_output_pin", fake_set_output_pin, raising=False)
+
+    response = gpio_client_next.patch("/next/gpio/10", params={"status": "true"})
+
+    assert response.status_code == 200
+    assert response.json() is True
+    assert captured["args"] == (10, True, True)
+
+
+def test_next_gpio_patch_returns_clear_conflict_for_busy_pin(monkeypatch, gpio_client_next):
+    module_path = "openscan_firmware.routers.next.gpio"
+    detail = "Cannot set pin 10. Pin is initialized as button input."
+
+    def fake_set_output_pin(pin: int, status: bool, auto_initialize: bool = False):
+        raise ValueError(detail)
+
+    monkeypatch.setattr(f"{module_path}.gpio.set_output_pin", fake_set_output_pin, raising=False)
+
+    response = gpio_client_next.patch("/next/gpio/10", params={"status": "true"})
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == detail

--- a/tests/utils/test_paths.py
+++ b/tests/utils/test_paths.py
@@ -1,0 +1,57 @@
+import pytest
+
+from openscan_firmware.models.paths import PathMethod, PolarPoint3D
+from openscan_firmware.utils.paths.paths import get_constrained_path
+
+
+def test_constrained_path_allows_fixed_theta() -> None:
+    path = get_constrained_path(
+        method=PathMethod.FIBONACCI,
+        num_points=5,
+        min_theta=45.0,
+        max_theta=45.0,
+        min_phi=0.0,
+        max_phi=180.0,
+    )
+
+    assert len(path) == 5
+    assert {point.theta for point in path} == {45.0}
+    assert len({point.fi for point in path}) > 1
+
+
+def test_constrained_path_allows_fixed_phi() -> None:
+    path = get_constrained_path(
+        method=PathMethod.FIBONACCI,
+        num_points=5,
+        min_theta=10.0,
+        max_theta=120.0,
+        min_phi=90.0,
+        max_phi=90.0,
+    )
+
+    assert len(path) == 5
+    assert {point.fi for point in path} == {90.0}
+    assert len({point.theta for point in path}) > 1
+
+
+def test_constrained_path_collapses_fully_fixed_position_to_one_point() -> None:
+    path = get_constrained_path(
+        method=PathMethod.FIBONACCI,
+        num_points=130,
+        min_theta=45.0,
+        max_theta=45.0,
+        min_phi=90.0,
+        max_phi=90.0,
+    )
+
+    assert path == [PolarPoint3D(theta=45.0, fi=90.0, r=1.0)]
+
+
+def test_constrained_path_still_rejects_reversed_theta_range() -> None:
+    with pytest.raises(ValueError, match="less than or equal"):
+        get_constrained_path(
+            method=PathMethod.FIBONACCI,
+            num_points=5,
+            min_theta=120.0,
+            max_theta=10.0,
+        )


### PR DESCRIPTION
This PR improves restrained path generation and coverage, allowing fully theta and phi restrained paths and thus effectively enabling e.g. a true turntable mode.