### PR TITLE
Rename `motors_timeout` to `idle_timeout` and add wakeup API endpoint

### DIFF
--- a/openscan_firmware/controllers/device.py
+++ b/openscan_firmware/controllers/device.py
@@ -144,6 +144,7 @@ def _runtime_to_persisted_config() -> ScannerDeviceConfig:
             name: PersistedEndstopConfig(settings=endstop.settings)
             for name, endstop in _scanner_device.endstops.items()
         },
+        idle_timeout=_scanner_device.idle_timeout,
         motors_timeout=_scanner_device.motors_timeout,
         scan_radius_mm=_scanner_device.scan_radius_mm,
         startup_mode=_scanner_device.startup_mode.value if _scanner_device.startup_mode else None,
@@ -270,6 +271,7 @@ def get_device_info():
         "lights": {name: controller.get_status() for name, controller in get_all_light_controllers().items()},
         "triggers": {name: controller.get_status() for name, controller in get_all_trigger_controllers().items()},
 
+        "idle_timeout": _scanner_device.idle_timeout,
         "motors_timeout": _scanner_device.motors_timeout,
         "scan_radius_mm": _scanner_device.scan_radius_mm,
         "startup_mode": _scanner_device.startup_mode,
@@ -696,7 +698,8 @@ async def _initialize_with_config(config: dict | ScannerDeviceConfig, detect_cam
         triggers=trigger_objects,
         endstops=endstop_objects,
 
-        # motors timeout in seconds - 0 to disable
+        # device idle timeout in seconds - 0 to disable
+        idle_timeout=config_dict["idle_timeout"],
         motors_timeout=config_dict["motors_timeout"],
         scan_radius_mm=config_dict["scan_radius_mm"],
         
@@ -709,11 +712,11 @@ async def _initialize_with_config(config: dict | ScannerDeviceConfig, detect_cam
     _scanner_device._initialized=True
 
     # initialize inactivity timer
-    if _scanner_device.motors_timeout > 0:
-        inactivity_timer.set_timeout(_scanner_device.motors_timeout)
+    if _scanner_device.idle_timeout > 0:
+        inactivity_timer.set_timeout(_scanner_device.idle_timeout)
         inactivity_timer.on_timeout = go_to_idle
         inactivity_timer.enable()
-        logger.info(f"Inactivity timer set to {_scanner_device.motors_timeout} seconds.")
+        logger.info(f"Inactivity timer set to {_scanner_device.idle_timeout} seconds.")
     else:
         inactivity_timer.disable()
         logger.info("Inactivity timer disabled.")

--- a/openscan_firmware/models/scanner.py
+++ b/openscan_firmware/models/scanner.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel, PrivateAttr, ConfigDict, Field
+from pydantic import BaseModel, PrivateAttr, ConfigDict, Field, model_validator
 
 from openscan_firmware.config.camera import CameraSettings
 from openscan_firmware.config.endstop import EndstopConfig
@@ -47,7 +47,9 @@ class ScannerDevice(BaseModel):
     triggers: dict[str, Trigger] = Field(default_factory=dict)
     endstops: Optional[dict[str, Endstop]]
     
-    # motors timeout in seconds - 0 to disable
+    # device idle timeout in seconds - 0 to disable
+    idle_timeout: float = 0.0
+    # backward compatibility alias for older code paths / payloads
     motors_timeout: float = 0.0
     scan_radius_mm: float = Field(
         default=1.0,
@@ -59,6 +61,14 @@ class ScannerDevice(BaseModel):
     
     _idle : bool = PrivateAttr(default=False)
     _initialized: bool = PrivateAttr(default=False)
+
+    @model_validator(mode="after")
+    def _sync_idle_timeout_fields(self) -> "ScannerDevice":
+        # Keep both names aligned to avoid breaking older callers.
+        if self.idle_timeout == 0.0 and self.motors_timeout != 0.0:
+            self.idle_timeout = self.motors_timeout
+        self.motors_timeout = self.idle_timeout
+        return self
 
 
 class PersistedCameraConfig(BaseModel):
@@ -84,7 +94,8 @@ class ScannerDeviceConfig(BaseModel):
     lights: dict[str, LightConfig] = Field(default_factory=dict)
     triggers: dict[str, TriggerConfig] = Field(default_factory=dict)
     endstops: dict[str, PersistedEndstopConfig] | None = None
-    motors_timeout: float = 0.0
+    idle_timeout: float = 0.0
+    motors_timeout: float | None = None
     scan_radius_mm: float = Field(
         default=1.0,
         gt=0.0,
@@ -92,3 +103,19 @@ class ScannerDeviceConfig(BaseModel):
     )
     startup_mode: ScannerStartupMode | str = ScannerStartupMode.STARTUP_ENABLED
     calibrate_mode: ScannerCalibrateMode | str = ScannerCalibrateMode.CALIBRATE_MANUAL
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_legacy_timeout_key(cls, data):
+        if isinstance(data, dict):
+            if "idle_timeout" not in data and "motors_timeout" in data:
+                data["idle_timeout"] = data["motors_timeout"]
+        return data
+
+    @model_validator(mode="after")
+    def _mirror_timeout_keys(self) -> "ScannerDeviceConfig":
+        # Persist both names for backward compatibility with existing tooling.
+        if self.idle_timeout == 0.0 and self.motors_timeout is not None and self.motors_timeout != 0.0:
+            self.idle_timeout = self.motors_timeout
+        self.motors_timeout = self.idle_timeout
+        return self

--- a/openscan_firmware/routers/next/device.py
+++ b/openscan_firmware/routers/next/device.py
@@ -37,6 +37,7 @@ class DeviceStatusResponse(BaseModel):
     motors: dict[str, MotorStatusResponse]
     lights: dict[str, LightStatusResponse]
     triggers: dict[str, TriggerStatusResponse] = Field(default_factory=dict)
+    idle_timeout: float
     motors_timeout: float
     scan_radius_mm: float = 1.0
     startup_mode: ScannerStartupMode

--- a/openscan_firmware/routers/next/device.py
+++ b/openscan_firmware/routers/next/device.py
@@ -347,6 +347,31 @@ async def reinitialize_hardware(detect_cameras: bool = False):
         raise HTTPException(status_code=500, detail=f"Error reloading hardware: {str(e)}")
 
 
+@router.post("/wakeup", response_model=DeviceControlResponse)
+async def wakeup_device():
+    """Wake up the device from idle mode.
+
+    If the device is already awake, this endpoint is a no-op and still returns success.
+    """
+    logger.info("Wakeup requested")
+    try:
+        was_idle = device.is_idle()
+        if was_idle:
+            await device.resume_from_idle()
+            if device._scanner_device.calibrate_mode == ScannerCalibrateMode.CALIBRATE_ON_WAKE:
+                await device.recalibrate_motors()
+
+        status = _runtime_status_response()
+        return DeviceControlResponse(
+            success=True,
+            message="Device awakened successfully" if was_idle else "Device already awake",
+            status=status,
+        )
+    except Exception as e:
+        logger.exception("Error waking device")
+        raise HTTPException(status_code=500, detail=f"Error waking device: {str(e)}")
+
+
 @router.post("/reboot", response_model=bool)
 def reboot(save_config: bool = False):
     """Reboot system and optionally save config.

--- a/openscan_firmware/routers/v0_8/device.py
+++ b/openscan_firmware/routers/v0_8/device.py
@@ -255,6 +255,28 @@ async def reinitialize_hardware(detect_cameras: bool = False):
         raise HTTPException(status_code=500, detail=f"Error reloading hardware: {str(e)}")
 
 
+@router.post("/wakeup", response_model=DeviceControlResponse)
+async def wakeup_device():
+    """Wake up the device from idle mode.
+
+    If the device is already awake, this endpoint is a no-op and still returns success.
+    """
+    try:
+        was_idle = device.is_idle()
+        if was_idle:
+            await device.resume_from_idle()
+            if device._scanner_device.calibrate_mode == ScannerCalibrateMode.CALIBRATE_ON_WAKE:
+                await device.recalibrate_motors()
+
+        return DeviceControlResponse(
+            success=True,
+            message="Device awakened successfully" if was_idle else "Device already awake",
+            status=_runtime_status_response(),
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error waking device: {str(e)}")
+
+
 @router.post("/reboot", response_model=bool)
 def reboot(save_config: bool = False):
     """Reboot system and optionally save config.

--- a/openscan_firmware/routers/v0_9/device.py
+++ b/openscan_firmware/routers/v0_9/device.py
@@ -344,6 +344,31 @@ async def reinitialize_hardware(detect_cameras: bool = False):
         raise HTTPException(status_code=500, detail=f"Error reloading hardware: {str(e)}")
 
 
+@router.post("/wakeup", response_model=DeviceControlResponse)
+async def wakeup_device():
+    """Wake up the device from idle mode.
+
+    If the device is already awake, this endpoint is a no-op and still returns success.
+    """
+    logger.info("Wakeup requested")
+    try:
+        was_idle = device.is_idle()
+        if was_idle:
+            await device.resume_from_idle()
+            if device._scanner_device.calibrate_mode == ScannerCalibrateMode.CALIBRATE_ON_WAKE:
+                await device.recalibrate_motors()
+
+        status = _runtime_status_response()
+        return DeviceControlResponse(
+            success=True,
+            message="Device awakened successfully" if was_idle else "Device already awake",
+            status=status,
+        )
+    except Exception as e:
+        logger.exception("Error waking device")
+        raise HTTPException(status_code=500, detail=f"Error waking device: {str(e)}")
+
+
 @router.post("/reboot", response_model=bool)
 def reboot(save_config: bool = False):
     """Reboot system and optionally save config.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openscan-firmware"
-version = "0.11.3"
+version = "0.11.4"
 description = "OpenScan3 - Raspberry Pi based photogrammetry scanner (FastAPI-based application)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/openapi/openapi_latest.json
+++ b/scripts/openapi/openapi_latest.json
@@ -5490,6 +5490,30 @@
             "title": "Pwm Support",
             "description": "Indicates whether this light hardware can handle PWM (otherwise only on/off).",
             "default": false
+          },
+          "pwm_frequency": {
+            "type": "number",
+            "maximum": 100000.0,
+            "minimum": 50.0,
+            "title": "Pwm Frequency",
+            "description": "PWM frequency for led driver.",
+            "default": 10000.0
+          },
+          "pwm_min": {
+            "type": "number",
+            "maximum": 3.3,
+            "minimum": 0.0,
+            "title": "Pwm Min",
+            "description": "Minimum pwm voltage for led driver.",
+            "default": 0.0
+          },
+          "pwm_max": {
+            "type": "number",
+            "maximum": 3.3,
+            "minimum": 0.0,
+            "title": "Pwm Max",
+            "description": "Maximum pwm voltage for led driver.",
+            "default": 3.3
           }
         },
         "type": "object",
@@ -6036,7 +6060,8 @@
               }
             ],
             "title": "Min Phi",
-            "description": "Optional minimum phi angle in degrees for constrained paths."
+            "description": "Optional minimum phi angle in degrees for constrained paths.",
+            "default": 0
           },
           "max_phi": {
             "anyOf": [
@@ -6050,7 +6075,8 @@
               }
             ],
             "title": "Max Phi",
-            "description": "Optional maximum phi angle in degrees for constrained paths."
+            "description": "Optional maximum phi angle in degrees for constrained paths.",
+            "default": 360.0
           },
           "optimize_path": {
             "type": "boolean",
@@ -6186,10 +6212,21 @@
             ],
             "title": "Endstops"
           },
-          "motors_timeout": {
+          "idle_timeout": {
             "type": "number",
-            "title": "Motors Timeout",
+            "title": "Idle Timeout",
             "default": 0.0
+          },
+          "motors_timeout": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Motors Timeout"
           },
           "scan_radius_mm": {
             "type": "number",

--- a/scripts/openapi/openapi_latest.json
+++ b/scripts/openapi/openapi_latest.json
@@ -3203,6 +3203,31 @@
         }
       }
     },
+    "/device/wakeup": {
+      "post": {
+        "tags": [
+          "device"
+        ],
+        "summary": "Wakeup Device",
+        "description": "Wake up the device from idle mode.\n\nIf the device is already awake, this endpoint is a no-op and still returns success.",
+        "operationId": "wakeup_device",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceControlResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
     "/device/reboot": {
       "post": {
         "tags": [

--- a/scripts/openapi/openapi_next.json
+++ b/scripts/openapi/openapi_next.json
@@ -3082,6 +3082,31 @@
         }
       }
     },
+    "/device/wakeup": {
+      "post": {
+        "tags": [
+          "device"
+        ],
+        "summary": "Wakeup Device",
+        "description": "Wake up the device from idle mode.\n\nIf the device is already awake, this endpoint is a no-op and still returns success.",
+        "operationId": "wakeup_device",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceControlResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
     "/device/reboot": {
       "post": {
         "tags": [

--- a/scripts/openapi/openapi_next.json
+++ b/scripts/openapi/openapi_next.json
@@ -1256,6 +1256,64 @@
         }
       }
     },
+    "/lights/{light_name}/intensity": {
+      "put": {
+        "tags": [
+          "lights"
+        ],
+        "summary": "Pwm Light",
+        "description": "Set light intensity\n\nArgs:\n    light_name: The name of the light to toggle\n    value: intensity of light, from 0% to 100%\n\nReturns:\n    LightStatusResponse: A response object containing the status of the light after the toggle operation",
+        "operationId": "pwm_light",
+        "parameters": [
+          {
+            "name": "light_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Light Name"
+            }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "description": "sets light intensity, from 0 to 100%",
+              "default": 100,
+              "title": "Value"
+            },
+            "description": "sets light intensity, from 0 to 100%"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LightStatusResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/lights/{name}/settings": {
       "get": {
         "tags": [
@@ -5818,6 +5876,10 @@
             "type": "object",
             "title": "Triggers"
           },
+          "idle_timeout": {
+            "type": "number",
+            "title": "Idle Timeout"
+          },
           "motors_timeout": {
             "type": "number",
             "title": "Motors Timeout"
@@ -5844,6 +5906,7 @@
           "cameras",
           "motors",
           "lights",
+          "idle_timeout",
           "motors_timeout",
           "startup_mode",
           "calibrate_mode",
@@ -6280,6 +6343,30 @@
             "title": "Pwm Support",
             "description": "Indicates whether this light hardware can handle PWM (otherwise only on/off).",
             "default": false
+          },
+          "pwm_frequency": {
+            "type": "number",
+            "maximum": 100000.0,
+            "minimum": 50.0,
+            "title": "Pwm Frequency",
+            "description": "PWM frequency for led driver.",
+            "default": 10000.0
+          },
+          "pwm_min": {
+            "type": "number",
+            "maximum": 3.3,
+            "minimum": 0.0,
+            "title": "Pwm Min",
+            "description": "Minimum pwm voltage for led driver.",
+            "default": 0.0
+          },
+          "pwm_max": {
+            "type": "number",
+            "maximum": 3.3,
+            "minimum": 0.0,
+            "title": "Pwm Max",
+            "description": "Maximum pwm voltage for led driver.",
+            "default": 3.3
           }
         },
         "type": "object",
@@ -6295,6 +6382,10 @@
             "type": "boolean",
             "title": "Is On"
           },
+          "value": {
+            "type": "number",
+            "title": "Value"
+          },
           "settings": {
             "$ref": "#/components/schemas/LightConfig"
           }
@@ -6303,6 +6394,7 @@
         "required": [
           "name",
           "is_on",
+          "value",
           "settings"
         ],
         "title": "LightStatusResponse"
@@ -6826,7 +6918,8 @@
               }
             ],
             "title": "Min Phi",
-            "description": "Optional minimum phi angle in degrees for constrained paths."
+            "description": "Optional minimum phi angle in degrees for constrained paths.",
+            "default": 0
           },
           "max_phi": {
             "anyOf": [
@@ -6840,7 +6933,8 @@
               }
             ],
             "title": "Max Phi",
-            "description": "Optional maximum phi angle in degrees for constrained paths."
+            "description": "Optional maximum phi angle in degrees for constrained paths.",
+            "default": 360.0
           },
           "optimize_path": {
             "type": "boolean",
@@ -6976,10 +7070,21 @@
             ],
             "title": "Endstops"
           },
-          "motors_timeout": {
+          "idle_timeout": {
             "type": "number",
-            "title": "Motors Timeout",
+            "title": "Idle Timeout",
             "default": 0.0
+          },
+          "motors_timeout": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Motors Timeout"
           },
           "scan_radius_mm": {
             "type": "number",

--- a/scripts/openapi/openapi_v0.8.json
+++ b/scripts/openapi/openapi_v0.8.json
@@ -5050,6 +5050,30 @@
             "title": "Pwm Support",
             "description": "Indicates whether this light hardware can handle PWM (otherwise only on/off).",
             "default": false
+          },
+          "pwm_frequency": {
+            "type": "number",
+            "maximum": 100000.0,
+            "minimum": 50.0,
+            "title": "Pwm Frequency",
+            "description": "PWM frequency for led driver.",
+            "default": 10000.0
+          },
+          "pwm_min": {
+            "type": "number",
+            "maximum": 3.3,
+            "minimum": 0.0,
+            "title": "Pwm Min",
+            "description": "Minimum pwm voltage for led driver.",
+            "default": 0.0
+          },
+          "pwm_max": {
+            "type": "number",
+            "maximum": 3.3,
+            "minimum": 0.0,
+            "title": "Pwm Max",
+            "description": "Maximum pwm voltage for led driver.",
+            "default": 3.3
           }
         },
         "type": "object",
@@ -5587,7 +5611,8 @@
               }
             ],
             "title": "Min Phi",
-            "description": "Optional minimum phi angle in degrees for constrained paths."
+            "description": "Optional minimum phi angle in degrees for constrained paths.",
+            "default": 0
           },
           "max_phi": {
             "anyOf": [
@@ -5601,7 +5626,8 @@
               }
             ],
             "title": "Max Phi",
-            "description": "Optional maximum phi angle in degrees for constrained paths."
+            "description": "Optional maximum phi angle in degrees for constrained paths.",
+            "default": 360.0
           },
           "optimize_path": {
             "type": "boolean",
@@ -5734,6 +5760,11 @@
               }
             ],
             "title": "Endstops"
+          },
+          "idle_timeout": {
+            "type": "number",
+            "title": "Idle Timeout",
+            "default": 0.0
           },
           "motors_timeout": {
             "type": "number",

--- a/scripts/openapi/openapi_v0.8.json
+++ b/scripts/openapi/openapi_v0.8.json
@@ -2932,6 +2932,31 @@
         }
       }
     },
+    "/device/wakeup": {
+      "post": {
+        "tags": [
+          "device"
+        ],
+        "summary": "Wakeup Device",
+        "description": "Wake up the device from idle mode.\n\nIf the device is already awake, this endpoint is a no-op and still returns success.",
+        "operationId": "wakeup_device",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceControlResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
     "/device/reboot": {
       "post": {
         "tags": [

--- a/scripts/openapi/openapi_v0.9.json
+++ b/scripts/openapi/openapi_v0.9.json
@@ -5490,6 +5490,30 @@
             "title": "Pwm Support",
             "description": "Indicates whether this light hardware can handle PWM (otherwise only on/off).",
             "default": false
+          },
+          "pwm_frequency": {
+            "type": "number",
+            "maximum": 100000.0,
+            "minimum": 50.0,
+            "title": "Pwm Frequency",
+            "description": "PWM frequency for led driver.",
+            "default": 10000.0
+          },
+          "pwm_min": {
+            "type": "number",
+            "maximum": 3.3,
+            "minimum": 0.0,
+            "title": "Pwm Min",
+            "description": "Minimum pwm voltage for led driver.",
+            "default": 0.0
+          },
+          "pwm_max": {
+            "type": "number",
+            "maximum": 3.3,
+            "minimum": 0.0,
+            "title": "Pwm Max",
+            "description": "Maximum pwm voltage for led driver.",
+            "default": 3.3
           }
         },
         "type": "object",
@@ -6036,7 +6060,8 @@
               }
             ],
             "title": "Min Phi",
-            "description": "Optional minimum phi angle in degrees for constrained paths."
+            "description": "Optional minimum phi angle in degrees for constrained paths.",
+            "default": 0
           },
           "max_phi": {
             "anyOf": [
@@ -6050,7 +6075,8 @@
               }
             ],
             "title": "Max Phi",
-            "description": "Optional maximum phi angle in degrees for constrained paths."
+            "description": "Optional maximum phi angle in degrees for constrained paths.",
+            "default": 360.0
           },
           "optimize_path": {
             "type": "boolean",
@@ -6186,10 +6212,21 @@
             ],
             "title": "Endstops"
           },
-          "motors_timeout": {
+          "idle_timeout": {
             "type": "number",
-            "title": "Motors Timeout",
+            "title": "Idle Timeout",
             "default": 0.0
+          },
+          "motors_timeout": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Motors Timeout"
           },
           "scan_radius_mm": {
             "type": "number",

--- a/scripts/openapi/openapi_v0.9.json
+++ b/scripts/openapi/openapi_v0.9.json
@@ -3203,6 +3203,31 @@
         }
       }
     },
+    "/device/wakeup": {
+      "post": {
+        "tags": [
+          "device"
+        ],
+        "summary": "Wakeup Device",
+        "description": "Wake up the device from idle mode.\n\nIf the device is already awake, this endpoint is a no-op and still returns success.",
+        "operationId": "wakeup_device",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceControlResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
     "/device/reboot": {
       "post": {
         "tags": [

--- a/tests/controllers/services/test_scan_task.py
+++ b/tests/controllers/services/test_scan_task.py
@@ -202,6 +202,8 @@ def test_generate_scan_path_omits_optional_phi_constraints_when_unset() -> None:
         points=10,
         min_theta=10.0,
         max_theta=120.0,
+        min_phi=None,
+        max_phi=None,
         optimize_path=False,
         focus_stacks=1,
         focus_range=(10.0, 15.0),

--- a/tests/routers/test_device_router.py
+++ b/tests/routers/test_device_router.py
@@ -75,6 +75,7 @@ def test_set_config_file_returns_factory_defaults(monkeypatch, tmp_path, device_
         "cameras": {},
         "motors": {},
         "lights": {},
+        "idle_timeout": 0.0,
         "motors_timeout": 0.0,
         "startup_mode": "startup_enabled",
         "calibrate_mode": "calibrate_manual",
@@ -191,6 +192,7 @@ def test_config_roundtrip_flow(monkeypatch, tmp_path, device_client, device_rout
         "cameras": {},
         "motors": {},
         "lights": {},
+        "idle_timeout": 0.0,
         "motors_timeout": 0.0,
         "startup_mode": "startup_enabled",
         "calibrate_mode": "calibrate_manual",
@@ -281,9 +283,11 @@ def test_reinitialize_endpoint_calls_controller(monkeypatch, device_client, devi
             "ring": {
                 "name": "ring",
                 "is_on": False,
+                "value": 100.0,
                 "settings": light_settings,
             }
         },
+        "idle_timeout": 0.0,
         "motors_timeout": 0.0,
         "startup_mode": "startup_enabled",
         "calibrate_mode": "calibrate_manual",

--- a/tests/routers/test_device_router.py
+++ b/tests/routers/test_device_router.py
@@ -313,3 +313,50 @@ def test_reinitialize_endpoint_calls_controller(monkeypatch, device_client, devi
     assert payload["status"]["initialized"] is True
     assert set(payload["status"]["motors"].keys()) == {"rotor"}
     assert set(payload["status"]["lights"].keys()) == {"ring"}
+
+
+def test_wakeup_endpoint_resumes_idle_device(monkeypatch, device_client, device_router_path):
+    module_path = device_router_path("device")
+
+    status_payload = {
+        "name": "Preset",
+        "model": "mini",
+        "shield": "greenshield",
+        "cameras": {},
+        "motors": {},
+        "lights": {},
+        "triggers": {},
+        "idle_timeout": 0.0,
+        "motors_timeout": 0.0,
+        "scan_radius_mm": 1.0,
+        "startup_mode": "startup_enabled",
+        "calibrate_mode": "calibrate_manual",
+        "initialized": True,
+    }
+    monkeypatch.setattr(f"{module_path}.device.get_device_info", lambda: status_payload, raising=False)
+
+    wake_calls = {"resume": 0, "recalibrate": 0}
+
+    monkeypatch.setattr(f"{module_path}.device.is_idle", lambda: True, raising=False)
+
+    async def fake_resume():
+        wake_calls["resume"] += 1
+
+    async def fake_recalibrate():
+        wake_calls["recalibrate"] += 1
+
+    monkeypatch.setattr(f"{module_path}.device.resume_from_idle", fake_resume, raising=False)
+    monkeypatch.setattr(f"{module_path}.device.recalibrate_motors", fake_recalibrate, raising=False)
+
+    class _ScannerDevice:
+        calibrate_mode = "calibrate_manual"
+
+    monkeypatch.setattr(f"{module_path}.device._scanner_device", _ScannerDevice(), raising=False)
+
+    response = device_client.post("/latest/device/wakeup")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["message"] == "Device awakened successfully"
+    assert wake_calls["resume"] == 1
+    assert wake_calls["recalibrate"] == 0

--- a/tests/routers/test_device_router_v0_8.py
+++ b/tests/routers/test_device_router_v0_8.py
@@ -138,6 +138,59 @@ def test_v08_reinitialize_endpoint_calls_controller(monkeypatch, device_client_v
     assert payload["message"] == "Hardware reinitialized successfully"
 
 
+def test_v08_wakeup_endpoint_resumes_idle_device(monkeypatch, device_client_v08, device_router_path_v08):
+    module_path = device_router_path_v08("device")
+
+    monkeypatch.setattr(
+        f"{module_path}.device.get_device_info",
+        lambda: {
+            "name": "Preset",
+            "model": "mini",
+            "shield": "greenshield",
+            "cameras": {},
+            "motors": {},
+            "lights": {},
+            "motors_timeout": 0.0,
+            "startup_mode": "startup_enabled",
+            "calibrate_mode": "calibrate_manual",
+            "initialized": True,
+        },
+        raising=False,
+    )
+
+    class _PassthroughStatus:
+        @staticmethod
+        def model_validate(payload):
+            return payload
+
+    monkeypatch.setattr(f"{module_path}.DeviceStatusResponse", _PassthroughStatus, raising=False)
+    monkeypatch.setattr(f"{module_path}.device.is_idle", lambda: True, raising=False)
+
+    wake_calls = {"resume": 0}
+
+    async def fake_resume():
+        wake_calls["resume"] += 1
+
+    async def fake_recalibrate():
+        raise AssertionError("recalibrate_motors should not be called in this scenario")
+
+    monkeypatch.setattr(f"{module_path}.device.resume_from_idle", fake_resume, raising=False)
+    monkeypatch.setattr(f"{module_path}.device.recalibrate_motors", fake_recalibrate, raising=False)
+
+    class _ScannerDevice:
+        calibrate_mode = "calibrate_manual"
+
+    monkeypatch.setattr(f"{module_path}.device._scanner_device", _ScannerDevice(), raising=False)
+
+    response = device_client_v08.post("/v0.8/device/wakeup")
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["message"] == "Device awakened successfully"
+    assert wake_calls["resume"] == 1
+
+
 def test_v08_add_config_json_rejects_persisted_shape(device_client_v08):
     repo_root = Path(__file__).resolve().parents[2]
     default_config = repo_root / "settings" / "device" / "default_mini_greenshield.json"

--- a/tests/routers/test_device_router_v0_9.py
+++ b/tests/routers/test_device_router_v0_9.py
@@ -1,0 +1,81 @@
+"""Baseline integration-style tests for the v0_9 device router contract."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Callable
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _v09_router_module_path(name: str) -> str:
+    return f"openscan_firmware.routers.v0_9.{name}"
+
+
+@pytest.fixture
+def device_client_v09() -> TestClient:
+    app = FastAPI()
+    device_router = import_module(_v09_router_module_path("device"))
+    app.include_router(device_router.router, prefix="/v0.9")
+    with TestClient(app) as client:
+        yield client
+
+
+@pytest.fixture
+def device_router_path_v09() -> Callable[[str], str]:
+    return _v09_router_module_path
+
+
+def test_v09_wakeup_endpoint_resumes_idle_device(monkeypatch, device_client_v09, device_router_path_v09):
+    module_path = device_router_path_v09("device")
+
+    monkeypatch.setattr(
+        f"{module_path}.device.get_device_info",
+        lambda: {
+            "name": "Preset",
+            "model": "mini",
+            "shield": "greenshield",
+            "cameras": {},
+            "motors": {},
+            "lights": {},
+            "motors_timeout": 0.0,
+            "startup_mode": "startup_enabled",
+            "calibrate_mode": "calibrate_manual",
+            "initialized": True,
+        },
+        raising=False,
+    )
+
+    class _PassthroughStatus:
+        @staticmethod
+        def model_validate(payload):
+            return payload
+
+    monkeypatch.setattr(f"{module_path}.DeviceStatusResponse", _PassthroughStatus, raising=False)
+    monkeypatch.setattr(f"{module_path}.device.is_idle", lambda: True, raising=False)
+
+    wake_calls = {"resume": 0}
+
+    async def fake_resume():
+        wake_calls["resume"] += 1
+
+    async def fake_recalibrate():
+        raise AssertionError("recalibrate_motors should not be called in this scenario")
+
+    monkeypatch.setattr(f"{module_path}.device.resume_from_idle", fake_resume, raising=False)
+    monkeypatch.setattr(f"{module_path}.device.recalibrate_motors", fake_recalibrate, raising=False)
+
+    class _ScannerDevice:
+        calibrate_mode = "calibrate_manual"
+
+    monkeypatch.setattr(f"{module_path}.device._scanner_device", _ScannerDevice(), raising=False)
+
+    response = device_client_v09.post("/v0.9/device/wakeup")
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["message"] == "Device awakened successfully"
+    assert wake_calls["resume"] == 1


### PR DESCRIPTION
This PR updates OpenAPI specs with the latest changes and renames the `motors_timeout` to `idle_timeout` device config flag.