### PR TITLE
fix(camera): improve Raspberry Pi 5 camera detection and diagnostics

### DIFF
--- a/openscan_firmware/controllers/device.py
+++ b/openscan_firmware/controllers/device.py
@@ -85,6 +85,8 @@ import time
 
 logger = logging.getLogger(__name__)
 
+_LINUXPY_INTERNAL_CAMERA_CARDS = {"unicam", "bcm2835-isp", "rp1-cfe", "pispbe"}
+
 # Current scanner model
 
 def _create_default_scanner_device() -> ScannerDevice:
@@ -346,12 +348,18 @@ def _detect_cameras() -> Dict[str, Camera]:
         linuxpycameras = iter_video_capture_devices()
         for cam in linuxpycameras:
             cam.open()
-            if cam.info.card not in ("unicam", "bcm2835-isp"):
+            card_name = str(cam.info.card)
+            if card_name.lower() not in _LINUXPY_INTERNAL_CAMERA_CARDS:
                 cameras[cam.info.card] = Camera(
                     type=CameraType.LINUXPY,
                     name=cam.info.card,
                     path=str(cam.filename),
                     settings=CameraSettings()
+                )
+            else:
+                logger.debug(
+                    "Skipping internal V4L2 pipeline device '%s' for LinuxPy camera detection.",
+                    card_name,
                 )
             cam.close()
     except Exception as e:

--- a/openscan_firmware/controllers/hardware/cameras/picamera2.py
+++ b/openscan_firmware/controllers/hardware/cameras/picamera2.py
@@ -225,6 +225,7 @@ class Picamera2Controller(CameraController):
         if additional_settings is not None:
             photogrammetry_settings.update(additional_settings)
 
+        self._photogrammetry_settings = photogrammetry_settings.copy()
         self.preview_config = self._strategy.create_preview_config(self._picam, self.settings.preview_resolution, photogrammetry_settings)
         self.photo_config = self._strategy.create_photo_config(self._picam, self.settings.photo_resolution, photogrammetry_settings)
         self.raw_config = self._strategy.create_raw_config(self._picam, self.settings.photo_resolution, photogrammetry_settings)
@@ -268,7 +269,10 @@ class Picamera2Controller(CameraController):
         x_start = (full_x - width) // 2
         y_start = (full_y - height) // 2
 
-        update_controls = {"ScalerCrop": (x_start, y_start, width, height)}
+        update_controls = {
+            **getattr(self, "_photogrammetry_settings", {}),
+            "ScalerCrop": (x_start, y_start, width, height),
+        }
         logger.debug("Updated ScalerCrop: ", update_controls)
         self.photo_config = self._strategy.create_photo_config(self._picam, (width, height), update_controls)
         self.raw_config = self._strategy.create_raw_config(self._picam, (width, height), update_controls)

--- a/openscan_firmware/routers/next/develop.py
+++ b/openscan_firmware/routers/next/develop.py
@@ -6,7 +6,9 @@ These may be removed or changed at any time.
 
 import base64
 import json
+import os
 import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import Literal
@@ -14,7 +16,11 @@ from typing import Literal
 from fastapi import APIRouter, HTTPException, status, Response, Query
 from fastapi.responses import PlainTextResponse
 
-from openscan_firmware.controllers.hardware.cameras.camera import get_all_camera_controllers
+from openscan_firmware.controllers.hardware.cameras.camera import (
+    create_camera_controller,
+    get_all_camera_controllers,
+    remove_camera_controller,
+)
 from openscan_firmware.controllers.services.tasks.task_manager import get_task_manager
 from openscan_firmware.models.camera import CameraType
 from openscan_firmware.models.task import TaskStatus, Task
@@ -33,6 +39,51 @@ router = APIRouter(
     tags=["develop"],
     responses={404: {"description": "Not found"}},
 )
+
+
+def _release_camera_controllers_for_report() -> tuple[list, dict]:
+    """Release OpenScan-owned cameras so external rpicam/libcamera probes can acquire them."""
+    controllers = get_all_camera_controllers()
+    busy = [
+        name
+        for name, controller in controllers.items()
+        if callable(getattr(controller, "is_busy", None)) and controller.is_busy()
+    ]
+    if busy:
+        return [], {
+            "released": False,
+            "reason": "camera busy",
+            "busy_cameras": busy,
+            "cameras": list(controllers.keys()),
+        }
+
+    camera_models = [controller.camera for controller in controllers.values()]
+    released: list[str] = []
+    errors: list[dict] = []
+    for name in list(controllers.keys()):
+        try:
+            if remove_camera_controller(name):
+                released.append(name)
+        except Exception as exc:
+            errors.append({"camera": name, "error": str(exc)})
+
+    return camera_models, {
+        "released": bool(released),
+        "cameras": released,
+        "errors": errors,
+    }
+
+
+def _restore_camera_controllers_after_report(camera_models: list) -> dict:
+    restored: list[str] = []
+    errors: list[dict] = []
+    for camera in camera_models:
+        try:
+            create_camera_controller(camera)
+            restored.append(camera.name)
+        except Exception as exc:
+            errors.append({"camera": camera.name, "error": str(exc)})
+    return {"restored": restored, "errors": errors}
 
 
 def _gp_text(value) -> str:  # noqa: ANN001
@@ -286,6 +337,10 @@ async def restart_application() -> dict[str, str]:
 @router.get("/camera-report")
 async def get_camera_report(
     format: Literal["json", "text"] = Query(default="json"),
+    release_cameras: bool = Query(
+        default=True,
+        description="Temporarily release OpenScan camera controllers so rpicam/libcamera probes can acquire cameras.",
+    ),
 ):
     """Run the camera diagnostics script and return a bundled report."""
     if not CAMERA_REPORT_SCRIPT.exists():
@@ -294,21 +349,36 @@ async def get_camera_report(
             detail=f"Camera report script not found: {CAMERA_REPORT_SCRIPT}",
         )
 
-    result = subprocess.run(
-        ["bash", str(CAMERA_REPORT_SCRIPT)],
-        capture_output=True,
-        text=True,
-        timeout=180,
-        check=False,
-    )
+    camera_models: list = []
+    camera_release = {"released": False, "reason": "disabled"}
+    camera_restore = {"restored": [], "errors": []}
+    if release_cameras:
+        camera_models, camera_release = _release_camera_controllers_for_report()
+
+    try:
+        result = subprocess.run(
+            ["bash", str(CAMERA_REPORT_SCRIPT)],
+            capture_output=True,
+            text=True,
+            timeout=180,
+            check=False,
+            env={**os.environ, "OPENSCAN_REPORT_PYTHON": sys.executable},
+        )
+    finally:
+        if camera_models:
+            camera_restore = _restore_camera_controllers_after_report(camera_models)
     report = result.stdout.strip()
     stderr = result.stderr.strip()
     gphoto2_diag = _collect_gphoto2_diagnostics()
 
     if format == "text":
         text_output = report or stderr or "No output produced."
+        camera_section = "===== OpenScan camera release for external probes =====\n" + json.dumps(
+            {"release": camera_release, "restore": camera_restore},
+            indent=2,
+        )
         gphoto2_section = "===== GPhoto2 python diagnostics =====\n" + json.dumps(gphoto2_diag, indent=2)
-        text_output = f"{text_output}\n\n{gphoto2_section}"
+        text_output = f"{text_output}\n\n{camera_section}\n\n{gphoto2_section}"
         status_code = status.HTTP_200_OK if result.returncode == 0 else status.HTTP_500_INTERNAL_SERVER_ERROR
         return PlainTextResponse(content=text_output, status_code=status_code)
 
@@ -316,6 +386,8 @@ async def get_camera_report(
         "ok": result.returncode == 0,
         "return_code": result.returncode,
         "script": str(CAMERA_REPORT_SCRIPT),
+        "camera_release": camera_release,
+        "camera_restore": camera_restore,
         "report": report,
         "stderr": stderr,
         "gphoto2": gphoto2_diag,

--- a/openscan_firmware/routers/v0_9/develop.py
+++ b/openscan_firmware/routers/v0_9/develop.py
@@ -6,7 +6,9 @@ These may be removed or changed at any time.
 
 import base64
 import json
+import os
 import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import Literal
@@ -14,6 +16,11 @@ from typing import Literal
 from fastapi import APIRouter, HTTPException, status, Response, Query
 from fastapi.responses import PlainTextResponse
 
+from openscan_firmware.controllers.hardware.cameras.camera import (
+    create_camera_controller,
+    get_all_camera_controllers,
+    remove_camera_controller,
+)
 from openscan_firmware.controllers.services.tasks.task_manager import get_task_manager
 from openscan_firmware.models.task import TaskStatus, Task
 
@@ -31,6 +38,51 @@ router = APIRouter(
     tags=["develop"],
     responses={404: {"description": "Not found"}},
 )
+
+
+def _release_camera_controllers_for_report() -> tuple[list, dict]:
+    """Release OpenScan-owned cameras so external rpicam/libcamera probes can acquire them."""
+    controllers = get_all_camera_controllers()
+    busy = [
+        name
+        for name, controller in controllers.items()
+        if callable(getattr(controller, "is_busy", None)) and controller.is_busy()
+    ]
+    if busy:
+        return [], {
+            "released": False,
+            "reason": "camera busy",
+            "busy_cameras": busy,
+            "cameras": list(controllers.keys()),
+        }
+
+    camera_models = [controller.camera for controller in controllers.values()]
+    released: list[str] = []
+    errors: list[dict] = []
+    for name in list(controllers.keys()):
+        try:
+            if remove_camera_controller(name):
+                released.append(name)
+        except Exception as exc:
+            errors.append({"camera": name, "error": str(exc)})
+
+    return camera_models, {
+        "released": bool(released),
+        "cameras": released,
+        "errors": errors,
+    }
+
+
+def _restore_camera_controllers_after_report(camera_models: list) -> dict:
+    restored: list[str] = []
+    errors: list[dict] = []
+    for camera in camera_models:
+        try:
+            create_camera_controller(camera)
+            restored.append(camera.name)
+        except Exception as exc:
+            errors.append({"camera": camera.name, "error": str(exc)})
+    return {"restored": restored, "errors": errors}
 
 
 def _gp_text(value) -> str:  # noqa: ANN001
@@ -241,6 +293,10 @@ async def restart_application() -> dict[str, str]:
 @router.get("/camera-report")
 async def get_camera_report(
     format: Literal["json", "text"] = Query(default="json"),
+    release_cameras: bool = Query(
+        default=True,
+        description="Temporarily release OpenScan camera controllers so rpicam/libcamera probes can acquire cameras.",
+    ),
 ):
     """Run the camera diagnostics script and return a bundled report."""
     if not CAMERA_REPORT_SCRIPT.exists():
@@ -249,21 +305,36 @@ async def get_camera_report(
             detail=f"Camera report script not found: {CAMERA_REPORT_SCRIPT}",
         )
 
-    result = subprocess.run(
-        ["bash", str(CAMERA_REPORT_SCRIPT)],
-        capture_output=True,
-        text=True,
-        timeout=180,
-        check=False,
-    )
+    camera_models: list = []
+    camera_release = {"released": False, "reason": "disabled"}
+    camera_restore = {"restored": [], "errors": []}
+    if release_cameras:
+        camera_models, camera_release = _release_camera_controllers_for_report()
+
+    try:
+        result = subprocess.run(
+            ["bash", str(CAMERA_REPORT_SCRIPT)],
+            capture_output=True,
+            text=True,
+            timeout=180,
+            check=False,
+            env={**os.environ, "OPENSCAN_REPORT_PYTHON": sys.executable},
+        )
+    finally:
+        if camera_models:
+            camera_restore = _restore_camera_controllers_after_report(camera_models)
     report = result.stdout.strip()
     stderr = result.stderr.strip()
     gphoto2_diag = _collect_gphoto2_diagnostics()
 
     if format == "text":
         text_output = report or stderr or "No output produced."
+        camera_section = "===== OpenScan camera release for external probes =====\n" + json.dumps(
+            {"release": camera_release, "restore": camera_restore},
+            indent=2,
+        )
         gphoto2_section = "===== GPhoto2 python diagnostics =====\n" + json.dumps(gphoto2_diag, indent=2)
-        text_output = f"{text_output}\n\n{gphoto2_section}"
+        text_output = f"{text_output}\n\n{camera_section}\n\n{gphoto2_section}"
         status_code = status.HTTP_200_OK if result.returncode == 0 else status.HTTP_500_INTERNAL_SERVER_ERROR
         return PlainTextResponse(content=text_output, status_code=status_code)
 
@@ -271,6 +342,8 @@ async def get_camera_report(
         "ok": result.returncode == 0,
         "return_code": result.returncode,
         "script": str(CAMERA_REPORT_SCRIPT),
+        "camera_release": camera_release,
+        "camera_restore": camera_restore,
         "report": report,
         "stderr": stderr,
         "gphoto2": gphoto2_diag,

--- a/scripts/camera_report.sh
+++ b/scripts/camera_report.sh
@@ -32,13 +32,101 @@ run_if_available() {
   fi
 }
 
+run_python_probe() {
+  local description="$1"
+  shift
+  print_section "$description"
+  "${OPENSCAN_REPORT_PYTHON:-python3}" - "$@" 2>&1
+  local rc=$?
+  if [ "$rc" -ne 0 ]; then
+    printf "[exit-code] %s\n" "$rc"
+  fi
+}
+
+run_camera_hello_probe() {
+  local binary="$1"
+  local description="$2"
+
+  print_section "$description"
+  if ! command -v "$binary" >/dev/null 2>&1; then
+    printf "%s not found in PATH\n" "$binary"
+    return
+  fi
+
+  printf "+ %s --version\n" "$binary"
+  "$binary" --version 2>&1 || printf "[exit-code] %s\n" "$?"
+
+  printf "\n+ %s --list-cameras\n" "$binary"
+  local list_output
+  list_output="$("$binary" --list-cameras 2>&1)"
+  local rc=$?
+  printf "%s\n" "$list_output"
+  if [ "$rc" -ne 0 ]; then
+    printf "[exit-code] %s\n" "$rc"
+    return
+  fi
+
+  local camera_indices=()
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^[[:space:]]*([0-9]+)[[:space:]]*: ]]; then
+      camera_indices+=("${BASH_REMATCH[1]}")
+    fi
+  done <<< "$list_output"
+
+  if [ "${#camera_indices[@]}" -eq 0 ]; then
+    echo "No cameras listed by $binary"
+    return
+  fi
+
+  for idx in "${camera_indices[@]}"; do
+    printf "\n--- %s camera %s hello probe ---\n" "$binary" "$idx"
+    printf "+ timeout 12s %s --camera %s --timeout 2000 --nopreview\n" "$binary" "$idx"
+    timeout 12s "$binary" --camera "$idx" --timeout 2000 --nopreview 2>&1
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+      printf "[exit-code] %s\n" "$rc"
+    fi
+  done
+}
+
 printf "OpenScan Camera Report\n"
 printf "Generated: %s\n" "$(date --iso-8601=seconds)"
 printf "Host: %s\n" "$(hostname)"
 printf "Kernel: %s\n" "$(uname -srmo)"
 
+run_python_probe "OpenScan firmware package info" <<'PY'
+import importlib
+from importlib.metadata import PackageNotFoundError, version
+
+packages = [
+    ("openscan-firmware", "openscan_firmware"),
+    ("picamera2", "picamera2"),
+    ("linuxpy", "linuxpy"),
+    ("gphoto2", "gphoto2"),
+]
+for package, module_name in packages:
+    try:
+        package_version = version(package)
+    except PackageNotFoundError:
+        package_version = "distribution metadata not found"
+
+    try:
+        module = importlib.import_module(module_name)
+        module_file = getattr(module, "__file__", "built-in")
+        import_status = f"import ok ({module_file})"
+    except Exception as exc:
+        import_status = f"import failed: {exc}"
+
+    print(f"{package}: {package_version}; module {module_name}: {import_status}")
+PY
+run_command "Python runtime" "${OPENSCAN_REPORT_PYTHON:-python3}" --version
+run_command "OpenScan service status" bash -lc 'systemctl status --no-pager -l openscan3.service 2>&1 || true'
+run_command "OpenScan service journal excerpts" bash -lc 'journalctl -u openscan3.service -n 160 --no-pager 2>&1 || true'
+run_command "Camera ownership diagnostics" bash -lc 'ps -eo pid,ppid,stat,comm,args | egrep "openscan3|python|CameraManager|IPAProxy|rpicam|libcamera" | egrep -v "egrep" || true; if command -v fuser >/dev/null 2>&1; then fuser -v /dev/video* /dev/media* 2>&1 || true; else echo "fuser not found in PATH"; fi'
 run_if_available "v4l2-ctl" "V4L2 device overview" v4l2-ctl --list-devices
 run_command "Video and media device nodes" bash -lc 'ls -l /dev/video* /dev/media* 2>/dev/null || echo "No /dev/video* or /dev/media* nodes found"'
+run_camera_hello_probe "rpicam-hello" "rpicam-hello camera probes"
+run_camera_hello_probe "libcamera-hello" "libcamera-hello legacy camera probes"
 run_if_available "lsusb" "USB device tree" lsusb -t
 run_if_available "lsusb" "USB device list" lsusb
 run_if_available "usb-devices" "USB devices (kernel view)" usb-devices

--- a/tests/controllers/hardware/picamera2/test_picamera2_focus_unit.py
+++ b/tests/controllers/hardware/picamera2/test_picamera2_focus_unit.py
@@ -99,3 +99,43 @@ def test_configure_focus_sets_default_manual_focus(monkeypatch):
     assert controller._picam.controls == [
         {"AfMode": module.controls.AfModeEnum.Manual, "LensPosition": 1.0}
     ]
+
+
+def test_configure_cropping_preserves_noise_reduction_controls(monkeypatch):
+    module = _import_picamera2_module(monkeypatch)
+
+    class _FakeStrategy:
+        def __init__(self):
+            self.photo_controls = None
+            self.raw_controls = None
+
+        def create_photo_config(self, _picam, _resolution, controls):
+            self.photo_controls = controls
+            return {"photo": controls}
+
+        def create_raw_config(self, _picam, _resolution, controls):
+            self.raw_controls = controls
+            return {"raw": controls}
+
+    strategy = _FakeStrategy()
+    controller = object.__new__(module.Picamera2Controller)
+    controller.settings = CameraSettings(crop_width=10, crop_height=20, orientation_flag=1)
+    controller.camera = types.SimpleNamespace(settings=controller.settings)
+    controller._picam = _FakePicam()
+    controller._strategy = strategy
+    controller._photogrammetry_settings = {
+        "AeEnable": False,
+        "NoiseReductionMode": 0,
+        "AwbEnable": False,
+    }
+
+    crop = controller._configure_cropping_for_scalercrop()
+
+    assert crop == (10, 10, 180, 80)
+    assert strategy.photo_controls == {
+        "AeEnable": False,
+        "NoiseReductionMode": 0,
+        "AwbEnable": False,
+        "ScalerCrop": crop,
+    }
+    assert strategy.raw_controls == strategy.photo_controls

--- a/tests/controllers/test_device_controller.py
+++ b/tests/controllers/test_device_controller.py
@@ -75,6 +75,39 @@ def device_module(monkeypatch):
     return _import_device(monkeypatch)
 
 
+def test_detect_cameras_skips_pi_internal_v4l2_pipeline_devices(monkeypatch):
+    device = _import_device(monkeypatch)
+
+    class DummyVideoDevice:
+        def __init__(self, card, filename):
+            self.info = types.SimpleNamespace(card=card)
+            self.filename = filename
+            self.closed = False
+
+        def open(self):
+            pass
+
+        def close(self):
+            self.closed = True
+
+    devices = [
+        DummyVideoDevice("rp1-cfe", "/dev/video0"),
+        DummyVideoDevice("pispbe", "/dev/video20"),
+        DummyVideoDevice("USB Camera", "/dev/video42"),
+    ]
+
+    monkeypatch.setattr(device, "iter_video_capture_devices", lambda: devices, raising=True)
+    monkeypatch.setattr(device, "is_camera_type_available", lambda camera_type: False, raising=True)
+
+    detected = device._detect_cameras()
+
+    assert "rp1-cfe" not in detected
+    assert "pispbe" not in detected
+    assert detected["USB Camera"].type == device.CameraType.LINUXPY
+    assert detected["USB Camera"].path == "/dev/video42"
+    assert all(video_device.closed for video_device in devices)
+
+
 def test_save_device_config_writes_json(tmp_path, monkeypatch,
                                         motor_model_instance,
                                         light_model_instance,

--- a/tests/routers/test_next_develop_router.py
+++ b/tests/routers/test_next_develop_router.py
@@ -22,12 +22,13 @@ def test_camera_report_returns_json(monkeypatch, tmp_path: Path):
     script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
     monkeypatch.setattr(develop_router, "CAMERA_REPORT_SCRIPT", script)
 
-    def fake_run(cmd, capture_output, text, timeout, check):  # noqa: ANN001
+    def fake_run(cmd, capture_output, text, timeout, check, env):  # noqa: ANN001
         assert cmd == ["bash", str(script)]
         assert capture_output is True
         assert text is True
         assert timeout == 180
         assert check is False
+        assert "OPENSCAN_REPORT_PYTHON" in env
         return subprocess.CompletedProcess(cmd, 0, stdout="camera report\n", stderr="")
 
     monkeypatch.setattr(develop_router.subprocess, "run", fake_run)
@@ -38,13 +39,15 @@ def test_camera_report_returns_json(monkeypatch, tmp_path: Path):
     )
 
     with TestClient(_create_app()) as client:
-        response = client.get("/next/develop/camera-report")
+        response = client.get("/next/develop/camera-report?release_cameras=false")
 
     assert response.status_code == 200
     assert response.json() == {
         "ok": True,
         "return_code": 0,
         "script": str(script),
+        "camera_release": {"released": False, "reason": "disabled"},
+        "camera_restore": {"restored": [], "errors": []},
         "report": "camera report",
         "stderr": "",
         "gphoto2": {"available": True, "error": None, "detected": [], "cameras": []},
@@ -78,9 +81,10 @@ def test_camera_report_text_includes_gphoto2_section(monkeypatch, tmp_path: Path
     )
 
     with TestClient(_create_app()) as client:
-        response = client.get("/next/develop/camera-report?format=text")
+        response = client.get("/next/develop/camera-report?format=text&release_cameras=false")
 
     assert response.status_code == 200
+    assert "===== OpenScan camera release for external probes =====" in response.text
     assert "report body" in response.text
     assert "===== GPhoto2 python diagnostics =====" in response.text
     assert "\"available\": false" in response.text


### PR DESCRIPTION
- Skipped internal V4L2 pipeline devices during LinuxPy camera detection.
- Fix picamera2 setting application on Raspberry Pi 5.
- Updated diagnostics script.
- Added temporary release of camera controllers to support external probes in diagnostics.
- Enhanced unit tests to validate new diagnostic and configuration behaviors.