### PR TITLE
fix(scan): await photo save so motor moves don't overlap encode/save

### DIFF
--- a/openscan_firmware/controllers/services/tasks/core/scan_task.py
+++ b/openscan_firmware/controllers/services/tasks/core/scan_task.py
@@ -452,9 +452,12 @@ class ScanTask(BaseTask):
                     scan_index=self._ctx.scan.index,
                 )
 
-                asyncio.create_task(self._ctx.project_manager.add_photo_async(photo_data))
-                # Needed so the event loop can process pause/cancel signals between captures:
-                await asyncio.sleep(0)
+                # Await the save instead of detaching it: a fire-and-forget create_task() lets the
+                # background JPEG write + per-photo size-recompute run DURING the next motor move,
+                # stealing CPU from the software-timed GPIO step loop -> dropped steps -> open-loop
+                # drift (no endstops). Awaiting serializes move -> capture -> save -> next move, so
+                # the motor only steps while the Pi is idle. (pause/cancel still checked at loop top.)
+                await self._ctx.project_manager.add_photo_async(photo_data)
             else:
                 # Focus stacking capture
                 focus_positions = self._ctx.focus_context["positions"]
@@ -488,9 +491,9 @@ class ScanTask(BaseTask):
                         stack_index=stack_index,
                     )
 
-                    asyncio.create_task(self._ctx.project_manager.add_photo_async(photo_data))
-                    # Let the event loop handle pause/cancel requests between focus captures
-                    await asyncio.sleep(0)
+                    # Await the save (see note above): keep the background save off the CPU while
+                    # the next move's GPIO stepping runs, so steps aren't dropped under load.
+                    await self._ctx.project_manager.add_photo_async(photo_data)
 
         except Exception as e:
             logger.error("Error taking photo at position %s: %s", index, e, exc_info=True)

--- a/openscan_firmware/controllers/services/tasks/core/scan_task.py
+++ b/openscan_firmware/controllers/services/tasks/core/scan_task.py
@@ -452,11 +452,8 @@ class ScanTask(BaseTask):
                     scan_index=self._ctx.scan.index,
                 )
 
-                # Await the save instead of detaching it: a fire-and-forget create_task() lets the
-                # background JPEG write + per-photo size-recompute run DURING the next motor move,
-                # stealing CPU from the software-timed GPIO step loop -> dropped steps -> open-loop
-                # drift (no endstops). Awaiting serializes move -> capture -> save -> next move, so
-                # the motor only steps while the Pi is idle. (pause/cancel still checked at loop top.)
+                # Await the save so executor-backed file/metadata work cannot overlap with the
+                # next software-timed motor move and disturb GPIO step timing.
                 await self._ctx.project_manager.add_photo_async(photo_data)
             else:
                 # Focus stacking capture
@@ -491,8 +488,7 @@ class ScanTask(BaseTask):
                         stack_index=stack_index,
                     )
 
-                    # Await the save (see note above): keep the background save off the CPU while
-                    # the next move's GPIO stepping runs, so steps aren't dropped under load.
+                    # Keep save work serialized with captures/moves; see single-photo path above.
                     await self._ctx.project_manager.add_photo_async(photo_data)
 
         except Exception as e:


### PR DESCRIPTION
Fixes #125

## Problem

During a scan the steppers grind/growl and drop steps. On an open-loop rig (no endstop) the lost steps make the firmware's position estimate drift by several degrees, which breaks homing and risks driving past the soft limits. The motion is smooth when the device is idle — the roughness only shows up under the CPU load of a running scan, which is the tell.

## Root cause

In `ScanTask._capture_photos_at_position` (`openscan_firmware/controllers/services/tasks/core/scan_task.py`) each photo is saved fire-and-forget — both the single-photo path and the focus-stacking path:

```python
asyncio.create_task(self._ctx.project_manager.add_photo_async(photo_data))
await asyncio.sleep(0)
```

The loop never awaits that task, so it proceeds straight to the next `await motors.move_to_point(...)` while the previous photo's save is still in flight. `add_photo_async` does the JPEG write + metadata + `_recalculate_and_save_scan_size` (an `os.walk` over the scan directory that grows with photo count), and hops into the default `ThreadPoolExecutor`. Meanwhile the motor move's stepping is a software, `time.sleep`-timed GPIO bit-bang running in `MotorController._executor`. The two thread pools contend for the CPU, the step-pulse intervals overrun, and steps are dropped. Open-loop + no endstop ⇒ the position estimate drifts.

## Fix

Await the save instead of detaching it, so each point is strictly `move → capture → save → next move`, and the motor only ever steps while the CPU is otherwise idle. (`pause`/`cancel` are still checked at the top of the loop, so dropping the `await asyncio.sleep(0)` yields nothing.)

## Verification

Patched both capture branches on an OpenScan Mini (greenshield, IMX519, firmware 0.11.4). Before: clearly audible growl/grinding during scans plus multi-degree homing drift. After: smooth and quiet, scans complete cleanly, and homing holds across repeated runs.

## Note / possible follow-up

Awaiting the save puts `_recalculate_and_save_scan_size` (which is `O(scan-dir)` and grows with photo count) on the per-photo critical path, so very large scans get somewhat slower. A reasonable follow-up is to move that size recompute off the per-photo path to scan end (`_cleanup_scan`). Happy to fold that into this PR or do it separately — left out here to keep the correctness fix minimal and easy to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
