### PR TITLE
refactor(scan_task): migrate photo capture to async method

### DIFF
--- a/openscan_firmware/controllers/services/tasks/core/scan_task.py
+++ b/openscan_firmware/controllers/services/tasks/core/scan_task.py
@@ -442,7 +442,7 @@ class ScanTask(BaseTask):
 
             if not self._ctx.focus_context or not self._ctx.focus_context["enabled"]:
                 # Single photo capture
-                photo_data = self._ctx.camera_controller.photo(
+                photo_data = await self._ctx.camera_controller.photo_async(
                     self._ctx.scan.settings.image_format
                 )
                 photo_data.scan_metadata = ScanMetadata(

--- a/tests/controllers/services/test_scan_task.py
+++ b/tests/controllers/services/test_scan_task.py
@@ -180,7 +180,7 @@ class TestScanTask:
         assert final_task_model.progress.total == total_expected_steps
 
         # 3. Check calls
-        assert mock_camera_controller.photo.call_count == total_expected_steps
+        assert mock_camera_controller.photo_async.await_count == total_expected_steps
         assert mock_project_manager.add_photo_async.call_count == total_expected_steps
         # +1 for the final cleanup move
         assert mock_motors.move_to_point.call_count == total_expected_steps + 1
@@ -733,7 +733,7 @@ async def test_capture_skips_photo_when_cancelled_before_capture_delay(sample_sc
 
 
     @pytest.mark.asyncio
-    async def test_single_capture_uses_configured_image_format(
+    async def test_single_capture_uses_async_camera_with_configured_image_format(
         self,
         sample_scan_model: Scan,
         fake_photo_data: PhotoData,
@@ -747,8 +747,8 @@ async def test_capture_skips_photo_when_cancelled_before_capture_delay(sample_sc
         photo_payload.format = "dng"
 
         camera_controller = MagicMock()
-        camera_controller.photo = MagicMock(return_value=photo_payload)
-        camera_controller.photo_async = AsyncMock()
+        camera_controller.photo = MagicMock()
+        camera_controller.photo_async = AsyncMock(return_value=photo_payload)
         camera_controller.settings = MagicMock()
 
         project_manager = MagicMock()
@@ -767,8 +767,8 @@ async def test_capture_skips_photo_when_cancelled_before_capture_delay(sample_sc
         await scan_task._capture_photos_at_position(PolarPoint3D(theta=0, fi=0), 0)
         await asyncio.sleep(0)
 
-        camera_controller.photo.assert_called_once()
-        assert camera_controller.photo.call_args.args == ("dng",)
+        camera_controller.photo.assert_not_called()
+        camera_controller.photo_async.assert_awaited_once_with("dng")
 
 
     @pytest.mark.asyncio


### PR DESCRIPTION
- Replaced `photo` with `photo_async` in `ScanTask` for asynchronous photo capture.
- Adjusted related test cases to mock and verify `photo_async` instead of `photo`.
- Ensured proper await usage for improved performance and stability during scan operations.